### PR TITLE
[FEAT-31] Implement Executions request message

### DIFF
--- a/lib/ib_ex/client/messages/executions/execution_data.ex
+++ b/lib/ib_ex/client/messages/executions/execution_data.ex
@@ -1,0 +1,54 @@
+defmodule IbEx.Client.Messages.Executions.ExecutionData do
+  @moduledoc """
+  Message received as a response of the Executions request message
+  """
+
+  alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Types.Execution
+
+  defstruct request_id: nil, contract: nil, execution: nil
+
+  @type t :: %__MODULE__{
+          request_id: String.t(),
+          contract: Contract.t(),
+          execution: Execution.t()
+        }
+
+  @contract_fields_length 11
+
+  @spec from_fields(List.t(binary())) :: {:ok, t()} | {:error, :invalid_args}
+  def from_fields([request_id, order_id | rest]) do
+    {contract_fields, execution_fields} = Enum.split(rest, @contract_fields_length)
+
+    with {:ok, contract} <- Contract.from_serialized_fields(contract_fields),
+         {:ok, execution} <- Execution.from_execution_data([order_id | execution_fields]) do
+      {
+        :ok,
+        %__MODULE__{
+          request_id: request_id,
+          contract: contract,
+          execution: execution
+        }
+      }
+    else
+      _ ->
+        {:error, :invalid_args}
+    end
+  end
+
+  def from_fields(_) do
+    {:error, :invalid_args}
+  end
+
+  defimpl Inspect, for: __MODULE__ do
+    def inspect(msg, _opts) do
+      """
+      <-- ExecutionData{
+        request_id: #{msg.request_id},
+        contract: #{inspect(msg.contract)},
+        execution: #{inspect(msg.execution)}
+      }
+      """
+    end
+  end
+end

--- a/lib/ib_ex/client/messages/executions/execution_data_end.ex
+++ b/lib/ib_ex/client/messages/executions/execution_data_end.ex
@@ -1,0 +1,29 @@
+defmodule IbEx.Client.Messages.Executions.ExecutionDataEnd do
+  @moduledoc """
+  Message received to mark the end of the executions stream for a given request id
+  """
+
+  defstruct version: nil, request_id: nil
+
+  @type t :: %__MODULE__{version: non_neg_integer(), request_id: binary()}
+
+  alias IbEx.Client.Utils
+
+  @spec from_fields(List.t(binary())) :: {:ok, t()} | {:error, :invalid_args}
+  def from_fields([version_str, request_id]) do
+    version = Utils.to_integer(version_str)
+    {:ok, %__MODULE__{version: version, request_id: request_id}}
+  end
+
+  def from_fields(_) do
+    {:error, :invalid_args}
+  end
+
+  defimpl Inspect, for: __MODULE__ do
+    def inspect(msg, _opts) do
+      """
+      <-- ExecutionDataEnd{version: #{msg.version}, request_id: #{msg.request_id}}
+      """
+    end
+  end
+end

--- a/lib/ib_ex/client/messages/executions/request.ex
+++ b/lib/ib_ex/client/messages/executions/request.ex
@@ -1,0 +1,77 @@
+defmodule IbEx.Client.Messages.Executions.Request do
+  @moduledoc """
+  Message used to request the executions of a given trading day.
+
+  According to the API docs, it's possible to get the executions of previous days by
+  opening in TWS the trade log and selecting previous days in the date range.
+
+  The input parameters to create this message are:
+
+  request_id: unique identifier for the request
+  executions_filter: Optional %ExecutionsFilter struct with the specifications of which executions to return
+  """
+
+  alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Types.ExecutionsFilter
+
+  @version 3
+
+  defstruct message_id: nil, version: @version, request_id: nil, filter: nil
+
+  @type t :: %__MODULE__{
+          message_id: integer(),
+          request_id: String.t(),
+          filter: ExecutionsFilter.t()
+        }
+
+  @spec new(String.t(), ExecutionsFilter.t()) :: {:ok, t()} | {:error, :not_implemented}
+  def new(request_id, executions_filter \\ %ExecutionsFilter{}) do
+    case Requests.message_id_for(__MODULE__) do
+      {:ok, message_id} ->
+        {
+          :ok,
+          %__MODULE__{
+            message_id: message_id,
+            request_id: request_id,
+            filter: executions_filter
+          }
+        }
+
+      _ ->
+        {:error, :not_implemented}
+    end
+  end
+
+  defimpl String.Chars, for: __MODULE__ do
+    alias IbEx.Client.Messages.Base
+
+    def to_string(msg) do
+      fields = [
+        msg.message_id,
+        msg.version,
+        msg.request_id,
+        msg.filter.client_id,
+        msg.filter.account_id,
+        msg.filter.time,
+        msg.filter.symbol,
+        msg.filter.security_type,
+        msg.filter.exchange,
+        msg.filter.side
+      ]
+
+      Base.build(fields)
+    end
+  end
+
+  defimpl Inspect, for: __MODULE__ do
+    def inspect(msg, _opts) do
+      """
+      --> Executions.Request{
+        message_id: #{msg.message_id},
+        request_id: #{msg.request_id},
+        filter: #{inspect(msg.filter)}
+      }
+      """
+    end
+  end
+end

--- a/lib/ib_ex/client/messages/init_connection/response.ex
+++ b/lib/ib_ex/client/messages/init_connection/response.ex
@@ -5,12 +5,13 @@ defmodule IbEx.Client.Messages.InitConnection.Response do
 
   defstruct server_version: nil, server_time: nil
 
-  require Logger
+  alias IbEx.Client.Utils
 
-  def from_fields([server_version, timestamp_str] = fields) do
+  def from_fields([server_version, timestamp_str]) do
+    [date, time | _] = String.split(timestamp_str, " ")
+
     with {version, _} <- Integer.parse(server_version),
-         {:ok, ts} <- parse_timestamp_str(timestamp_str),
-         ts <- Timex.Timezone.convert(ts, "Etc/UTC") do
+         {:ok, ts} <- Utils.parse_timestamp_str("#{date} #{time} CET") do
       {:ok,
        %__MODULE__{
          server_version: version,
@@ -18,20 +19,15 @@ defmodule IbEx.Client.Messages.InitConnection.Response do
        }}
     else
       _ ->
-        Logger.error("Error parsing expected InitConnection / ConnectionAck response: #{inspect(fields)}")
+        {:error, :unexpected_error}
     end
+  rescue
+    _ ->
+      {:error, :unexpected_error}
   end
 
-  def from_fields(fields) do
-    Logger.warning("Trying to parse message as InitConnection / ConnectionAck response: #{inspect(fields)}")
+  def from_fields(_) do
     {:error, :invalid_args}
-  end
-
-  # This is an ugly hack but solves the issue of Timex not being able to parse
-  # through %Z the value of "Central European Standard Time"
-  defp parse_timestamp_str(timestamp_string) do
-    [date, time | _] = String.split(timestamp_string, " ")
-    Timex.parse("#{date} #{time} CET", "%Y%m%d %k:%M:%S %Z", :strftime)
   end
 
   defimpl Inspect, for: __MODULE__ do

--- a/lib/ib_ex/client/messages/matching_symbols/symbol_samples.ex
+++ b/lib/ib_ex/client/messages/matching_symbols/symbol_samples.ex
@@ -37,7 +37,7 @@ defmodule IbEx.Client.Messages.MatchingSymbols.SymbolSamples do
 
   defp parse_descriptions(fields, accum) do
     with {contract_fields, rest} <- extract_contract_fields(fields),
-         {:ok, description} <- ContractDescription.from_fields(contract_fields) do
+         {:ok, description} <- ContractDescription.from_symbol_samples(contract_fields) do
       parse_descriptions(rest, [description] ++ accum)
     end
   rescue

--- a/lib/ib_ex/client/messages/orders/decoder.ex
+++ b/lib/ib_ex/client/messages/orders/decoder.ex
@@ -130,8 +130,14 @@ defmodule IbEx.Client.Messages.Orders.Decoder do
 
   defp parse_contract_data(%{unprocessed: fields} = msg) do
     {contract_data, rest} = Enum.split(fields, 11)
-    contract = Contract.deserialize(contract_data)
-    Map.merge(msg, %{contract: contract, unprocessed: rest})
+
+    case Contract.from_serialized_fields(contract_data) do
+      {:ok, contract} ->
+        Map.merge(msg, %{contract: contract, unprocessed: rest})
+
+      _ ->
+        msg
+    end
   end
 
   defp batch_parse_params(%{unprocessed: fields} = msg, keys) do

--- a/lib/ib_ex/client/messages/requests.ex
+++ b/lib/ib_ex/client/messages/requests.ex
@@ -8,7 +8,7 @@ defmodule IbEx.Client.Messages.Requests do
     "cancel_order" => 4,
     "open_orders" => 5,
     Messages.AccountData.Request => 6,
-    "executions" => 7,
+    Messages.Executions.Request => 7,
     Messages.Ids.Request => 8,
     "contract_data" => 9,
     "market_depth" => 10,

--- a/lib/ib_ex/client/types/contract_description.ex
+++ b/lib/ib_ex/client/types/contract_description.ex
@@ -16,8 +16,8 @@ defmodule IbEx.Client.Types.ContractDescription do
 
   @extra_fields_size 2
 
-  @spec from_fields(list()) :: {:ok, t()} | {:error, :invalid_args}
-  def from_fields([con_id, symbol, sec_type, exchange, currency, _ | rest]) do
+  @spec from_symbol_samples(list()) :: {:ok, t()} | {:error, :invalid_args}
+  def from_symbol_samples([con_id, symbol, sec_type, exchange, currency, _ | rest]) do
     derivatives_length = length(rest) - @extra_fields_size
 
     {derivatives, [description, issuer_id]} = Enum.split(rest, derivatives_length)
@@ -38,7 +38,7 @@ defmodule IbEx.Client.Types.ContractDescription do
       {:error, :invalid_args}
   end
 
-  def from_fields(_) do
+  def from_symbol_samples(_) do
     {:error, :invalid_args}
   end
 

--- a/lib/ib_ex/client/types/execution.ex
+++ b/lib/ib_ex/client/types/execution.ex
@@ -1,0 +1,104 @@
+defmodule IbEx.Client.Types.Execution do
+  @moduledoc """
+  Represents a trade by the user
+  """
+
+  defstruct execution_id: "",
+            timestamp: "",
+            account_id: "",
+            exchange: "",
+            side: "",
+            size: 0,
+            price: 0.0,
+            perm_id: 0,
+            client_id: 0,
+            order_id: 0,
+            liquidation: 0,
+            cumulative_quantity: Decimal.new("0"),
+            average_price: Decimal.new("0.0"),
+            order_ref: "",
+            ev_rule: "",
+            ev_multiplier: Decimal.new("0.0"),
+            model_code: "",
+            last_liquidity: 0,
+            pending_price_revision: false
+
+  @type t :: %__MODULE__{
+          execution_id: String.t(),
+          timestamp: DateTime.t(),
+          account_id: String.t(),
+          exchange: String.t(),
+          side: String.t(),
+          size: float(),
+          price: float(),
+          perm_id: non_neg_integer(),
+          client_id: non_neg_integer(),
+          order_id: any(),
+          liquidation: non_neg_integer(),
+          cumulative_quantity: Decimal.t(),
+          average_price: float(),
+          order_ref: String.t(),
+          ev_rule: String.t(),
+          ev_multiplier: float(),
+          model_code: String.t(),
+          last_liquidity: non_neg_integer(),
+          pending_price_revision: boolean()
+        }
+
+  alias IbEx.Client.Utils
+
+  def from_execution_data([
+        order_id,
+        execution_id,
+        time,
+        account_id,
+        exchange,
+        side,
+        size,
+        price,
+        perm_id,
+        client_id,
+        liquidation,
+        cumulative_quantity,
+        average_price,
+        order_ref,
+        ev_rule,
+        ev_mult,
+        model_code,
+        last_liq,
+        pending_price_revision
+      ]) do
+    with {:ok, ts} <- Utils.parse_timestamp_str(time) do
+      {
+        :ok,
+        %__MODULE__{
+          order_id: order_id,
+          execution_id: execution_id,
+          timestamp: ts,
+          account_id: account_id,
+          exchange: exchange,
+          side: side,
+          size: Utils.to_float(size),
+          price: Utils.to_float(price),
+          perm_id: Utils.to_integer(perm_id),
+          client_id: Utils.to_integer(client_id),
+          liquidation: Utils.to_integer(liquidation),
+          cumulative_quantity: Utils.to_decimal(cumulative_quantity),
+          average_price: Utils.to_float(average_price),
+          order_ref: order_ref,
+          ev_rule: ev_rule,
+          ev_multiplier: Utils.to_float(ev_mult),
+          model_code: model_code,
+          last_liquidity: Utils.to_integer(last_liq),
+          pending_price_revision: Utils.to_bool(pending_price_revision)
+        }
+      }
+    else
+      _ ->
+        {:error, :invalid_args}
+    end
+  rescue
+    _ ->
+      {:error, :invalid_args}
+  end
+end

--- a/lib/ib_ex/client/types/executions_filter.ex
+++ b/lib/ib_ex/client/types/executions_filter.ex
@@ -1,0 +1,46 @@
+defmodule IbEx.Client.Types.ExecutionsFilter do
+  @moduledoc """
+  Represents the filter used on the executions request message.
+
+  It's used to filter out executions by the following parameters:
+  * Client Id
+  * Account Code
+  * Time
+  * Symbol
+  * Security Type
+  * Exchange
+  * Side
+  """
+
+  @type t :: %__MODULE__{
+          client_id: String.t() | nil,
+          account_id: String.t() | nil,
+          time: String.t() | nil,
+          symbol: String.t() | nil,
+          security_type: String.t() | nil,
+          exchange: String.t() | nil,
+          side: String.t() | nil
+        }
+
+  defstruct client_id: nil, account_id: nil, time: nil, symbol: nil, security_type: nil, exchange: nil, side: nil
+
+  @spec new(Keyword.t()) :: {:ok, t} | {:error, :invalid_args}
+  def new(opts) when is_list(opts) do
+    {
+      :ok,
+      %__MODULE__{
+        client_id: Keyword.get(opts, :client_id),
+        account_id: Keyword.get(opts, :account_id),
+        time: Keyword.get(opts, :time),
+        symbol: Keyword.get(opts, :symbol),
+        security_type: Keyword.get(opts, :security_type),
+        exchange: Keyword.get(opts, :exchange),
+        side: Keyword.get(opts, :side)
+      }
+    }
+  end
+
+  def new(_) do
+    {:error, :invalid_args}
+  end
+end

--- a/lib/ib_ex/client/types/trade.ex
+++ b/lib/ib_ex/client/types/trade.ex
@@ -1,6 +1,6 @@
 defmodule IbEx.Client.Types.Trade do
   @moduledoc """
-  Represents a trade from the Time & Sales feed.
+  Represents a trade from the public Time & Sales feed.
   """
 
   defstruct timestamp: nil,

--- a/lib/ib_ex/client/utils.ex
+++ b/lib/ib_ex/client/utils.ex
@@ -23,10 +23,60 @@ defmodule IbEx.Client.Utils do
         nil
 
       @unset_double ->
-        Decimal.new("0")
+        nil
+
+      "" ->
+        nil
 
       other when is_binary(other) ->
         Decimal.new(other)
     end
+  end
+
+  def to_float(str) do
+    case str do
+      nil ->
+        nil
+
+      "" ->
+        nil
+
+      other when is_binary(other) ->
+        other
+        |> Float.parse()
+        |> elem(0)
+    end
+  rescue
+    _ ->
+      nil
+  end
+
+  def to_integer(str) do
+    String.to_integer(str)
+  rescue
+    _ ->
+      nil
+  end
+
+  def to_bool(str) when str in ["0", "1"] do
+    String.to_integer(str) != 0
+  end
+
+  def to_bool(_) do
+    nil
+  end
+
+  def parse_timestamp_str(str) when is_binary(str) do
+    case Timex.parse(str, "%Y%m%d %k:%M:%S %Z", :strftime) do
+      {:ok, ts} ->
+        {:ok, Timex.Timezone.convert(ts, "Etc/UTC")}
+
+      _ ->
+        {:error, :invalid_args}
+    end
+  end
+
+  def parse_timestamp_str(_) do
+    {:error, :invalid_args}
   end
 end

--- a/test/ib_ex/client/messages/base_test.exs
+++ b/test/ib_ex/client/messages/base_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.BaseTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Base
 

--- a/test/ib_ex/client/messages/executions/execution_data_end_test.exs
+++ b/test/ib_ex/client/messages/executions/execution_data_end_test.exs
@@ -1,0 +1,33 @@
+defmodule IbEx.Client.Messages.Executions.ExecutionDataEndTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Messages.Executions.ExecutionDataEnd
+
+  describe "from_fields/1" do
+    test "creates an ExecutionDataEnd with valid fields" do
+      assert {:ok, msg} = ExecutionDataEnd.from_fields(["3", "request123"])
+
+      assert msg.version == 3
+      assert msg.request_id == "request123"
+    end
+
+    test "returns an error with invalid number of fields" do
+      assert {:error, :invalid_args} == ExecutionDataEnd.from_fields(["3"])
+    end
+
+    test "returns an error with non-list input" do
+      assert {:error, :invalid_args} == ExecutionDataEnd.from_fields(nil)
+    end
+  end
+
+  describe "inspect/2" do
+    test "returns a human-readable version of the message" do
+      msg = %ExecutionDataEnd{version: 3, request_id: "request123"}
+
+      assert inspect(msg) ==
+               """
+               <-- ExecutionDataEnd{version: 3, request_id: request123}
+               """
+    end
+  end
+end

--- a/test/ib_ex/client/messages/executions/execution_data_test.exs
+++ b/test/ib_ex/client/messages/executions/execution_data_test.exs
@@ -1,0 +1,148 @@
+defmodule IbEx.Client.Messages.Executions.ExecutionDataTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Messages.Executions.ExecutionData
+  alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Types.Execution
+
+  describe "from_fields/1" do
+    test "creates an ExecutionData with valid fields" do
+      fields = [
+        "90001",
+        "0",
+        "520512263",
+        "GTLB",
+        "STK",
+        "",
+        "0.0",
+        "",
+        "",
+        "ISLAND",
+        "USD",
+        "GTLB",
+        "",
+        "00025b44.656e0e0c.01.01",
+        "20231204 22:39:34 Europe/Madrid",
+        "DU3494644",
+        "ISLAND",
+        "BOT",
+        "100",
+        "61.54",
+        "727593489",
+        "0",
+        "0",
+        "1600",
+        "61.496875",
+        "MktDepth",
+        "",
+        "",
+        "",
+        "1",
+        "0"
+      ]
+
+      assert {:ok, msg} = ExecutionData.from_fields(fields)
+
+      assert msg.request_id == "90001"
+
+      assert msg.contract == %Contract{
+               combo_legs: [],
+               combo_legs_description: nil,
+               conid: "520512263",
+               currency: "USD",
+               delta_neutral_contract: nil,
+               description: "",
+               exchange: "ISLAND",
+               include_expired: false,
+               issuer_id: "",
+               last_trade_date_or_contract_month: "",
+               local_symbol: "GTLB",
+               multiplier: "",
+               primary_exchange: "",
+               right: "",
+               security_id: "",
+               security_id_type: "",
+               security_type: "STK",
+               strike: "0.0",
+               symbol: "GTLB",
+               trading_class: ""
+             }
+
+      assert msg.execution == %Execution{
+               account_id: "DU3494644",
+               average_price: 61.496875,
+               client_id: 0,
+               cumulative_quantity: Decimal.new("1600"),
+               ev_multiplier: nil,
+               ev_rule: "",
+               exchange: "ISLAND",
+               execution_id: "00025b44.656e0e0c.01.01",
+               last_liquidity: 1,
+               liquidation: 0,
+               model_code: "",
+               order_id: "0",
+               order_ref: "MktDepth",
+               pending_price_revision: false,
+               perm_id: 727_593_489,
+               price: 61.54,
+               side: "BOT",
+               size: 100.0,
+               timestamp: ~U[2023-12-04 21:39:34Z]
+             }
+    end
+
+    test "returns an error with invalid fields" do
+      invalid_fields = ["invalid", "fields"]
+      assert {:error, :invalid_args} == ExecutionData.from_fields(invalid_fields)
+    end
+  end
+
+  describe "inspect/2" do
+    test "returns a human-readable version of the message" do
+      fields = [
+        "90001",
+        "0",
+        "520512263",
+        "GTLB",
+        "STK",
+        "",
+        "0.0",
+        "",
+        "",
+        "ISLAND",
+        "USD",
+        "GTLB",
+        "",
+        "00025b44.656e0e0c.01.01",
+        "20231204 22:39:34 Europe/Madrid",
+        "DU3494644",
+        "ISLAND",
+        "BOT",
+        "100",
+        "61.54",
+        "727593489",
+        "0",
+        "0",
+        "1600",
+        "61.496875",
+        "MktDepth",
+        "",
+        "",
+        "",
+        "1",
+        "0"
+      ]
+
+      {:ok, msg} = ExecutionData.from_fields(fields)
+
+      assert inspect(msg) ==
+               """
+               <-- ExecutionData{
+                 request_id: 90001,
+                 contract: %IbEx.Client.Types.Contract{conid: "520512263", symbol: "GTLB", security_type: "STK", last_trade_date_or_contract_month: "", strike: "0.0", right: "", multiplier: "", exchange: "ISLAND", currency: "USD", local_symbol: "GTLB", primary_exchange: "", trading_class: "", include_expired: false, security_id_type: "", security_id: "", combo_legs_description: nil, combo_legs: [], delta_neutral_contract: nil, description: "", issuer_id: ""},
+                 execution: %IbEx.Client.Types.Execution{execution_id: "00025b44.656e0e0c.01.01", timestamp: ~U[2023-12-04 21:39:34Z], account_id: "DU3494644", exchange: "ISLAND", side: "BOT", size: 100.0, price: 61.54, perm_id: 727593489, client_id: 0, order_id: "0", liquidation: 0, cumulative_quantity: Decimal.new("1600"), average_price: 61.496875, order_ref: "MktDepth", ev_rule: "", ev_multiplier: nil, model_code: "", last_liquidity: 1, pending_price_revision: false}
+               }
+               """
+    end
+  end
+end

--- a/test/ib_ex/client/messages/executions/request_test.exs
+++ b/test/ib_ex/client/messages/executions/request_test.exs
@@ -1,0 +1,48 @@
+defmodule IbEx.Client.Messages.Executions.RequestTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Messages.Executions.Request
+  alias IbEx.Client.Types.ExecutionsFilter
+
+  describe "new/2" do
+    test "creates a Request with valid inputs" do
+      assert {:ok, msg} = Request.new("90001", %ExecutionsFilter{client_id: 123})
+
+      assert msg.message_id == 7
+      assert msg.request_id == "90001"
+      assert msg.filter == %ExecutionsFilter{client_id: 123}
+    end
+  end
+
+  describe "String.Chars implementation" do
+    test "converts Request struct to string" do
+      msg = %Request{
+        message_id: 7,
+        version: 3,
+        request_id: "90001",
+        filter: %ExecutionsFilter{client_id: 123}
+      }
+
+      assert to_string(msg) == <<55, 0, 51, 0, 57, 48, 48, 48, 49, 0, 49, 50, 51, 0, 0, 0, 0, 0, 0, 0>>
+    end
+  end
+
+  describe "inspect/2" do
+    test "returns a human-readable version of the message" do
+      msg = %Request{
+        message_id: 7,
+        request_id: "90001",
+        filter: %ExecutionsFilter{client_id: 123}
+      }
+
+      assert inspect(msg) ==
+               """
+               --> Executions.Request{
+                 message_id: 7,
+                 request_id: 90001,
+                 filter: %IbEx.Client.Types.ExecutionsFilter{client_id: 123, account_id: nil, time: nil, symbol: nil, security_type: nil, exchange: nil, side: nil}
+               }
+               """
+    end
+  end
+end

--- a/test/ib_ex/client/messages/matching_symbols/request_test.exs
+++ b/test/ib_ex/client/messages/matching_symbols/request_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.MatchingSymbols.RequestTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MatchingSymbols.Request
 

--- a/test/ib_ex/client/messages/matching_symbols/symbol_samples_test.exs
+++ b/test/ib_ex/client/messages/matching_symbols/symbol_samples_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.MatchingSymbols.SymbolSamplesTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MatchingSymbols.SymbolSamples
   alias IbEx.Client.Types.Contract

--- a/test/ib_ex/client/messages/pnl/all_positions_request_test.exs
+++ b/test/ib_ex/client/messages/pnl/all_positions_request_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.Pnl.AllPositionsRequestTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.AllPositionsRequest
 

--- a/test/ib_ex/client/messages/pnl/all_positions_update_test.exs
+++ b/test/ib_ex/client/messages/pnl/all_positions_update_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.Pnl.AllPositionsUpdateTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.AllPositionsUpdate
 

--- a/test/ib_ex/client/messages/pnl/single_position_request_test.exs
+++ b/test/ib_ex/client/messages/pnl/single_position_request_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.Pnl.SinglePositionRequestTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.SinglePositionRequest
 

--- a/test/ib_ex/client/messages/pnl/single_position_update_test.exs
+++ b/test/ib_ex/client/messages/pnl/single_position_update_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdateTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.SinglePositionUpdate
 
@@ -11,7 +11,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdateTest do
       assert msg.request_id == "90004"
       assert msg.position == 0
       assert msg.daily_pnl == Decimal.new("1.665208")
-      assert msg.unrealized_pnl == Decimal.new("0")
+      assert is_nil(msg.unrealized_pnl)
       assert msg.realized_pnl == Decimal.new("1.665208")
       assert msg.value == Decimal.new("0.0")
     end

--- a/test/ib_ex/client/messages/start_api/request_test.exs
+++ b/test/ib_ex/client/messages/start_api/request_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.StartApi.RequestTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.StartApi.Request
 

--- a/test/ib_ex/client/messages/tick_by_tick_data/tick_by_tick_test.exs
+++ b/test/ib_ex/client/messages/tick_by_tick_data/tick_by_tick_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Messages.TickByTickData.TickByTickTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.TickByTickData.TickByTick
 

--- a/test/ib_ex/client/types/bid_ask_test.exs
+++ b/test/ib_ex/client/types/bid_ask_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Types.BidAskTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Types.BidAsk
 

--- a/test/ib_ex/client/types/contract_description_test.exs
+++ b/test/ib_ex/client/types/contract_description_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Types.ContractDescriptionTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Types.ContractDescription
@@ -20,10 +20,10 @@ defmodule IbEx.Client.Types.ContractDescriptionTest do
     ""
   ]
 
-  describe "from_fields/1" do
+  describe "from_symbol_samples/1" do
     test "returns the contract description" do
       assert {:ok, %ContractDescription{contract: contract, derivative_security_types: derivatives}} =
-               ContractDescription.from_fields(@valid_fields)
+               ContractDescription.from_symbol_samples(@valid_fields)
 
       assert contract == %Contract{
                conid: "265598",
@@ -39,11 +39,11 @@ defmodule IbEx.Client.Types.ContractDescriptionTest do
     end
 
     test "returns invalid args when called with something other than a list" do
-      assert {:error, :invalid_args} == ContractDescription.from_fields(%{})
+      assert {:error, :invalid_args} == ContractDescription.from_symbol_samples(%{})
     end
 
     test "returns invalid args when called with a list in a different format" do
-      assert {:error, :invalid_args} == ContractDescription.from_fields(["1", "2", "3"])
+      assert {:error, :invalid_args} == ContractDescription.from_symbol_samples(["1", "2", "3"])
     end
   end
 end

--- a/test/ib_ex/client/types/contract_test.exs
+++ b/test/ib_ex/client/types/contract_test.exs
@@ -1,0 +1,119 @@
+defmodule IbEx.Client.Types.ContractTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.Contract
+
+  describe "new/1" do
+    test "creates a Contract with valid attributes" do
+      attrs = %{conid: "520512263", symbol: "GTLB", security_type: "STK"}
+      assert Contract.new(attrs) == %Contract{conid: "520512263", symbol: "GTLB", security_type: "STK"}
+    end
+  end
+
+  describe "serialize/2" do
+    test "serializes a Contract including expired field" do
+      contract = %Contract{conid: "520512263", symbol: "GTLB", security_type: "STK", include_expired: true}
+
+      assert Contract.serialize(contract) == [
+               "520512263",
+               "GTLB",
+               "STK",
+               "",
+               "0.0",
+               "",
+               "",
+               "SMART",
+               "",
+               "",
+               "",
+               "",
+               true
+             ]
+    end
+
+    test "serializes a Contract without including expired field" do
+      contract = %Contract{conid: "520512263", symbol: "GTLB", security_type: "STK", include_expired: false}
+
+      assert Contract.serialize(contract, false) == [
+               "520512263",
+               "GTLB",
+               "STK",
+               "",
+               "0.0",
+               "",
+               "",
+               "SMART",
+               "",
+               "",
+               "",
+               ""
+             ]
+    end
+  end
+
+  describe "from_serialized_fields/1" do
+    test "creates a Contract with valid serialized fields" do
+      assert {:ok, contract} =
+               Contract.from_serialized_fields([
+                 "520512263",
+                 "GTLB",
+                 "STK",
+                 "",
+                 "0.0",
+                 "",
+                 "",
+                 "ISLAND",
+                 "USD",
+                 "GTLB",
+                 ""
+               ])
+
+      assert contract == %Contract{
+               conid: "520512263",
+               symbol: "GTLB",
+               security_type: "STK",
+               last_trade_date_or_contract_month: "",
+               strike: "0.0",
+               right: "",
+               multiplier: "",
+               exchange: "ISLAND",
+               currency: "USD",
+               local_symbol: "GTLB",
+               trading_class: ""
+             }
+    end
+
+    test "returns an error with invalid number of fields" do
+      assert {:error, :invalid_args} == Contract.from_serialized_fields(["520512263", "GTLB"])
+    end
+
+    test "returns an error with non-list input" do
+      assert {:error, :invalid_args} == Contract.from_serialized_fields(nil)
+    end
+  end
+
+  describe "rights/0" do
+    test "returns the different types of rights a contract can have" do
+      assert Contract.rights() == ["C", "CALL", "P", "PUT", "?"]
+    end
+  end
+
+  describe "security_types/0" do
+    test "returns the different types of security_types a contract can have" do
+      assert Contract.security_types() == [
+               "STK",
+               "OPT",
+               "FUT",
+               "IND",
+               "FOP",
+               "CASH",
+               "BAG",
+               "WAR",
+               "BOND",
+               "CMDTY",
+               "NEWS",
+               "FUND"
+             ]
+    end
+  end
+end

--- a/test/ib_ex/client/types/execution_test.exs
+++ b/test/ib_ex/client/types/execution_test.exs
@@ -1,0 +1,63 @@
+defmodule IbEx.Client.Types.ExecutionTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.Execution
+
+  describe "from_execution_data/1" do
+    test "creates an Execution with valid fields" do
+      fields = [
+        "order123",
+        "exec123",
+        "20231204 22:39:34 Europe/Madrid",
+        "acc123",
+        "NYSE",
+        "BUY",
+        "100",
+        "61.54",
+        "727593489",
+        "0",
+        "0",
+        "100",
+        "61.54",
+        "ref123",
+        "rule1",
+        "2.0",
+        "modelABC",
+        "1",
+        "0"
+      ]
+
+      assert {:ok, execution} = Execution.from_execution_data(fields)
+
+      assert execution.order_id == "order123"
+      assert execution.execution_id == "exec123"
+      assert execution.timestamp == ~U[2023-12-04 21:39:34Z]
+      assert execution.account_id == "acc123"
+      assert execution.exchange == "NYSE"
+      assert execution.side == "BUY"
+      assert execution.size == 100.0
+      assert execution.price == 61.54
+      assert execution.perm_id == 727_593_489
+      assert execution.client_id == 0
+      assert execution.liquidation == 0
+      assert execution.cumulative_quantity == Decimal.new("100")
+      assert execution.average_price == 61.54
+      assert execution.order_ref == "ref123"
+      assert execution.ev_rule == "rule1"
+      assert execution.ev_multiplier == 2.0
+      assert execution.model_code == "modelABC"
+      assert execution.last_liquidity == 1
+      assert execution.pending_price_revision == false
+    end
+
+    test "returns an error with invalid timestamp" do
+      invalid_fields = List.duplicate("valid", 18) ++ ["invalid-timestamp"]
+      assert {:error, :invalid_args} == Execution.from_execution_data(invalid_fields)
+    end
+
+    test "returns an error with invalid fields" do
+      invalid_fields = List.duplicate("invalid", 19)
+      assert {:error, :invalid_args} == Execution.from_execution_data(invalid_fields)
+    end
+  end
+end

--- a/test/ib_ex/client/types/executions_filter_test.exs
+++ b/test/ib_ex/client/types/executions_filter_test.exs
@@ -1,0 +1,57 @@
+defmodule IbEx.Client.Types.ExecutionsFilterTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.ExecutionsFilter
+
+  describe "new/1" do
+    test "creates an ExecutionsFilter with valid options" do
+      opts = [
+        client_id: 123,
+        account_id: "ABC123",
+        time: "2023-12-05",
+        symbol: "XYZ",
+        security_type: "STOCK",
+        exchange: "NYSE",
+        side: "BUY"
+      ]
+
+      {:ok, filter} = ExecutionsFilter.new(opts)
+      assert filter.client_id == 123
+      assert filter.account_id == "ABC123"
+      assert filter.time == "2023-12-05"
+      assert filter.symbol == "XYZ"
+      assert filter.security_type == "STOCK"
+      assert filter.exchange == "NYSE"
+      assert filter.side == "BUY"
+    end
+
+    test "returns an error with invalid input" do
+      invalid_input = "invalid"
+      assert {:error, :invalid_args} == ExecutionsFilter.new(invalid_input)
+    end
+
+    test "creates an ExecutionsFilter with partial options" do
+      opts = [client_id: 123, account_id: "ABC123"]
+
+      {:ok, filter} = ExecutionsFilter.new(opts)
+      assert filter.client_id == 123
+      assert filter.account_id == "ABC123"
+      assert is_nil(filter.time)
+      assert is_nil(filter.symbol)
+      assert is_nil(filter.security_type)
+      assert is_nil(filter.exchange)
+      assert is_nil(filter.side)
+    end
+
+    test "handles empty options" do
+      {:ok, filter} = ExecutionsFilter.new([])
+      assert is_nil(filter.client_id)
+      assert is_nil(filter.account_id)
+      assert is_nil(filter.time)
+      assert is_nil(filter.symbol)
+      assert is_nil(filter.security_type)
+      assert is_nil(filter.exchange)
+      assert is_nil(filter.side)
+    end
+  end
+end

--- a/test/ib_ex/client/types/mid_point_test.exs
+++ b/test/ib_ex/client/types/mid_point_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Types.MidPointTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias IbEx.Client.Types.MidPoint
 
   describe "from_tick_by_tick/1" do

--- a/test/ib_ex/client/types/trade_test.exs
+++ b/test/ib_ex/client/types/trade_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.Types.TradeTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Types.Trade
 

--- a/test/ib_ex/client/utils_test.exs
+++ b/test/ib_ex/client/utils_test.exs
@@ -1,5 +1,5 @@
 defmodule IbEx.Client.UtilsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias IbEx.Client.Utils
 
@@ -25,6 +25,62 @@ defmodule IbEx.Client.UtilsTest do
       assert Utils.boolify_mask("15", "2") == true
       assert Utils.boolify_mask("5", 2) == false
       assert Utils.boolify_mask(5, "1") == true
+    end
+  end
+
+  describe "parse_timestamp_str/1" do
+    test "parses valid timestamp string correctly" do
+      assert {:ok, ts} = Utils.parse_timestamp_str("20231204 22:39:34 Europe/Madrid")
+      assert ts == ~U[2023-12-04 21:39:34Z]
+    end
+
+    test "handles invalid timestamp string" do
+      assert {:error, :invalid_args} == Utils.parse_timestamp_str("")
+    end
+
+    test "handles other types of args" do
+      assert {:error, :invalid_args} == Utils.parse_timestamp_str(nil)
+    end
+
+    test "handles timestamp string with incorrect format" do
+      assert {:error, :invalid_args} == Utils.parse_timestamp_str("2023-12-05 15:30:00")
+    end
+  end
+
+  describe "to_decimal/1" do
+    test "converts valid string to Decimal" do
+      assert Utils.to_decimal("123.45") == Decimal.new("123.45")
+    end
+
+    test "returns nil for invalid or special inputs" do
+      assert is_nil(Utils.to_decimal(nil))
+      assert is_nil(Utils.to_decimal(""))
+      assert is_nil(Utils.to_decimal("1.7976931348623157E308"))
+    end
+  end
+
+  describe "to_float/1" do
+    test "converts valid string to float" do
+      assert Utils.to_float("123.45") == 123.45
+    end
+
+    test "returns nil for invalid inputs" do
+      assert is_nil(Utils.to_float(nil))
+      assert is_nil(Utils.to_float(""))
+      assert is_nil(Utils.to_float("invalid"))
+    end
+  end
+
+  describe "to_bool/1" do
+    test "converts string '1' to true and '0' to false" do
+      assert Utils.to_bool("1") == true
+      assert Utils.to_bool("0") == false
+    end
+
+    test "handles non-numeric strings" do
+      assert is_nil(Utils.to_bool("invalid"))
+      assert is_nil(Utils.to_bool("123"))
+      assert is_nil(Utils.to_bool("-1"))
     end
   end
 end


### PR DESCRIPTION
Implements the following messages:

* `Executions.Request` to request a download of the daily executions
* `Executions.ExecutionData` as a response of individual executions
* `Executions.ExecutionDataEnd` to signal the end of the download of executions