### PR TITLE
[FEAT-127] Defer request id creation to the client

### DIFF
--- a/lib/ib_ex/client/messages/account_data/account_detail.ex
+++ b/lib/ib_ex/client/messages/account_data/account_detail.ex
@@ -71,6 +71,8 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetail do
 
   defstruct version: nil, field: nil, value: nil, currency: nil, account: nil
 
+  alias IbEx.Client.Protocols.Subscribable
+
   def from_fields([version_str, field, value, currency, account]) do
     case Integer.parse(version_str) do
       {version, _} ->
@@ -97,6 +99,19 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetail do
   defimpl Inspect, for: __MODULE__ do
     def inspect(msg, _opts) do
       "<-- AccountDetail{field: #{msg.field}, value: #{msg.value}, currency: #{msg.currency}, account: #{msg.account}}"
+    end
+  end
+
+  defimpl Subscribable, for: __MODULE__ do
+    alias IbEx.Client.Messages.AccountData.AccountDetail
+    alias IbEx.Client.Subscriptions
+
+    def subscribe(_, _, _) do
+      {:error, :response_messages_cannot_create_subscription}
+    end
+
+    def lookup(_msg, table_ref) do
+      Subscriptions.lookup(table_ref, AccountDetail)
     end
   end
 end

--- a/lib/ib_ex/client/messages/account_data/account_download_end.ex
+++ b/lib/ib_ex/client/messages/account_data/account_download_end.ex
@@ -5,6 +5,8 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEnd do
 
   defstruct version: nil, account: nil
 
+  alias IbEx.Client.Protocols.Subscribable
+
   def from_fields([version_str, account]) do
     case Integer.parse(version_str) do
       {version, _} ->
@@ -28,6 +30,19 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEnd do
   defimpl Inspect, for: __MODULE__ do
     def inspect(msg, _opts) do
       "<-- AccountDownloadEnd{account: #{msg.account}}"
+    end
+  end
+
+  defimpl Subscribable, for: __MODULE__ do
+    alias IbEx.Client.Messages.AccountData.AccountDownloadEnd
+    alias IbEx.Client.Subscriptions
+
+    def subscribe(_, _, _) do
+      {:error, :response_messages_cannot_create_subscription}
+    end
+
+    def lookup(_msg, table_ref) do
+      Subscriptions.lookup(table_ref, AccountDownloadEnd)
     end
   end
 end

--- a/lib/ib_ex/client/messages/account_data/account_update_time.ex
+++ b/lib/ib_ex/client/messages/account_data/account_update_time.ex
@@ -6,6 +6,8 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTime do
 
   defstruct version: nil, timestamp: nil
 
+  alias IbEx.Client.Protocols.Subscribable
+
   @spec from_fields([String.t()]) :: {:ok, %__MODULE__{}} | {:error, :invalid_args}
   def from_fields([version_str, hour_minute]) do
     with {version, ""} <- Integer.parse(version_str),
@@ -33,6 +35,19 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTime do
   defimpl Inspect, for: __MODULE__ do
     def inspect(msg, _opts) do
       "<-- AccountUpdateTime{timestamp: #{msg.timestamp}}"
+    end
+  end
+
+  defimpl Subscribable, for: __MODULE__ do
+    alias IbEx.Client.Messages.AccountData.AccountUpdateTime
+    alias IbEx.Client.Subscriptions
+
+    def subscribe(_, _, _) do
+      {:error, :response_messages_cannot_create_subscription}
+    end
+
+    def lookup(_msg, table_ref) do
+      Subscriptions.lookup(table_ref, AccountUpdateTime)
     end
   end
 end

--- a/lib/ib_ex/client/messages/account_data/request.ex
+++ b/lib/ib_ex/client/messages/account_data/request.ex
@@ -1,4 +1,79 @@
 defmodule IbEx.Client.Messages.AccountData.Request do
+  @moduledoc """
+  Request to receive updates related to the account data
+
+  For the account used in tests the following data fields are received through the AccountDetail message:
+
+  * AccountCode
+  * AccountOrGroup with variations for each currency held in the account
+  * AccountReady
+  * AccountType
+  * AccruedCash (currency variants)
+  * AvailableFunds
+  * Billable
+  * BuyingPower
+  * CashBalance (currency variants)
+  * ColumnPrio-S ???
+  * CorporateBondValue (currency variants)
+  * Currency (currencies in the account)
+  * Cushion ???
+  * EquityWithLoanValue
+  * ExcessLiquidity
+  * ExchangeRate between currencies held in account
+  * FullAvailableFunds
+  * FullExcessLiquidity
+  * FullInitMarginReq
+  * FullMaintMarginReq
+  * FundValue (currency variations)
+  * FutureOptionValue (currency variations)
+  * FuturesPNL (currency variations)
+  * FxCashBalance (currency varaitions)
+  * GrossPositionValue
+  * Guarantee
+  * IndianSockHaircut ???
+  * InitMarginReq
+  * IssuerOptionValue (currency variants)
+  * Leverage-S ???
+  * LookAheadAvailableFunds
+  * LookAheadExcessLiquidity
+  * LookAheadInitMarginReq
+  * LookAheadMaintMarginReq
+  * LookAheadNextChange
+  * MaintMarginReq
+  * MoneyMarketFundValue (currency variants)
+  * MutualFundValue (currency variants)
+  * NLVAndMarginInReview
+  * NetDividend (currency variants)
+  * NetLIquidation
+  * NetLiquidationByCurrency (currency variants)
+  * NetLiquidationUncertainty
+  * OptionMarketValue (currency variants)
+  * PASharesValue
+  * PhysicalCertificatesValue
+  * PostExpirationExcess
+  * PostExpirationMargin
+  * RealCurrency (currency variants)
+  * RealizedPnL (currency variants)
+  * SegmentTitle-S
+  * StockMarketValue (currency variants)
+  * TBillValue (currency variants)
+  * TBondValue (currency variants)
+  * TotalCashBalance (currency variants)
+  * TotalCashValue
+  * TotalDebitCardPendingCharges
+  * TradingType-S
+  * UnrealizedPnL (currency variants)
+  * WarrantValue (currency variants)
+
+  As secondary messages we receive the AccountUpdateTime and AccountDownloadEnd
+
+  The subscribe param allows for continuous updates to be received, though even with subscribed
+  set to true, the AccountDownloadEnd message is received at least once and the AccountUpdateTime
+  is received twice per update
+
+  In order to unsubscribe from the account updates feed we need to send this message with the subscribe param set to false,
+  to confirm this we receive an Info message saying the API client is unsubscribed from account data
+  """
   @message_version 1
 
   alias IbEx.Client.Messages.Base

--- a/lib/ib_ex/client/messages/base.ex
+++ b/lib/ib_ex/client/messages/base.ex
@@ -47,4 +47,14 @@ defmodule IbEx.Client.Messages.Base do
   def make_field(thing) when is_tuple(thing) or is_map(thing), do: make_field("")
 
   def make_field(field), do: to_string(field) <> "\x00"
+
+  defimpl IbEx.Client.Protocols.Subscribable, for: Any do
+    def subscribe(_, _, _) do
+      {:error, :not_implemented}
+    end
+
+    def lookup(_, _) do
+      {:error, :not_implemented}
+    end
+  end
 end

--- a/lib/ib_ex/client/messages/matching_symbols/request.ex
+++ b/lib/ib_ex/client/messages/matching_symbols/request.ex
@@ -1,17 +1,21 @@
 defmodule IbEx.Client.Messages.MatchingSymbols.Request do
+  @moduledoc """
+  Request message for symbol to Contract lookups in IBKR
+  """
+
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Subscribable
 
   defstruct pattern: nil, request_id: nil, message_id: nil
 
-  def new(opts \\ []) do
-    with {:ok, id} <- Requests.message_id_for(__MODULE__),
-         {:ok, request_id} <- Keyword.fetch(opts, :request_id),
-         {:ok, pattern} <- Keyword.fetch(opts, :pattern) do
-      {:ok, %__MODULE__{message_id: id, request_id: request_id, pattern: pattern}}
-    else
+  def new(pattern) do
+    case Requests.message_id_for(__MODULE__) do
+      {:ok, id} ->
+        {:ok, %__MODULE__{message_id: id, pattern: pattern}}
+
       _ ->
-        {:error, :invalid_args}
+        {:error, :not_implemented}
     end
   end
 
@@ -26,6 +30,20 @@ defmodule IbEx.Client.Messages.MatchingSymbols.Request do
   defimpl Inspect, for: __MODULE__ do
     def inspect(msg, _opts) do
       "--> MatchingSymbols{id: #{msg.message_id}, request_id: #{msg.request_id}, pattern: #{msg.pattern}}"
+    end
+  end
+
+  defimpl Subscribable, for: __MODULE__ do
+    alias IbEx.Client.Subscriptions
+
+    # Subscription based on request_id, can handle multiple requests
+    def subscribe(msg, pid, table_ref) do
+      request_id = Subscriptions.subscribe_by_request_id(table_ref, pid)
+      {:ok, %{msg | request_id: request_id}}
+    end
+
+    def lookup(_, _) do
+      {:error, :lookup_not_necessary}
     end
   end
 end

--- a/lib/ib_ex/client/messages/matching_symbols/symbol_samples.ex
+++ b/lib/ib_ex/client/messages/matching_symbols/symbol_samples.ex
@@ -9,6 +9,7 @@ defmodule IbEx.Client.Messages.MatchingSymbols.SymbolSamples do
   defstruct request_id: nil, contracts: []
 
   alias IbEx.Client.Types.ContractDescription
+  alias IbEx.Client.Protocols.Subscribable
 
   require Logger
 
@@ -51,5 +52,17 @@ defmodule IbEx.Client.Messages.MatchingSymbols.SymbolSamples do
   defp extract_contract_fields(fields) do
     derivatives_length = String.to_integer(Enum.at(fields, @derivatives_length_position))
     Enum.split(fields, @base_fields_length + derivatives_length)
+  end
+
+  defimpl Subscribable, for: __MODULE__ do
+    alias IbEx.Client.Subscriptions
+
+    def subscribe(_, _, _) do
+      {:error, :response_messages_cannot_create_subscription}
+    end
+
+    def lookup(msg, table_ref) do
+      Subscriptions.lookup(table_ref, msg.request_id)
+    end
   end
 end

--- a/lib/ib_ex/client/messages/responses.ex
+++ b/lib/ib_ex/client/messages/responses.ex
@@ -12,7 +12,7 @@ defmodule IbEx.Client.Messages.Responses do
     "5" => Messages.Orders.OpenOrder,
     "6" => Messages.AccountData.AccountDetail,
     "7" => "portfolio_value",
-    "8" => Messages.AccountData.AccountDetail,
+    "8" => Messages.AccountData.AccountUpdateTime,
     "9" => Messages.Ids.NextValidId,
     "10" => "contract_data",
     "11" => Messages.Executions.ExecutionData,

--- a/lib/ib_ex/client/protocols/subscribable.ex
+++ b/lib/ib_ex/client/protocols/subscribable.ex
@@ -1,0 +1,24 @@
+defprotocol IbEx.Client.Protocols.Subscribable do
+  @moduledoc """
+  Defines a protocol for message requests sent to TWS and their responses to be relayed back
+  to a process through a mapping kept in an ETS table by our Client process.
+  """
+
+  @fallback_to_any true
+
+  @doc """
+  Subscribes a message and its responses to a subscriber process, either through a
+  request_id in the message itself (when it's a field sent out in the request)
+  or through mapping the response message struct with the subscriber process
+
+  Returns the message
+  """
+  def subscribe(msg, subscriber_pid, table_id)
+
+  @doc """
+  Looks up the subscriber process for a given message
+
+  Returns a PID
+  """
+  def lookup(msg, table_id)
+end

--- a/lib/ib_ex/client/subscriptions.ex
+++ b/lib/ib_ex/client/subscriptions.ex
@@ -1,0 +1,37 @@
+defmodule IbEx.Client.Subscriptions do
+  @moduledoc """
+  Handles initialization of the ETS table used by the client
+  to map request ids or structs of a given message responses to the
+  process that requested sending the message 
+  """
+
+  def initialize do
+    table_ref = :ets.new(:message_subscriptions, [:set, :private])
+    :ets.insert(table_ref, {:message_request_ids, 1})
+    table_ref
+  end
+
+  def subscribe_by_request_id(table_ref, pid) do
+    [message_request_ids: next_request_id] = :ets.lookup(table_ref, :message_request_ids)
+
+    :ets.insert(table_ref, {to_string(next_request_id), pid})
+    :ets.update_counter(table_ref, :message_request_ids, {2, 1})
+
+    next_request_id
+  end
+
+  def subscribe_by_modules(table_ref, modules, pid) when is_list(modules) do
+    Enum.each(modules, &:ets.insert(table_ref, {&1, pid}))
+    :ok
+  end
+
+  def lookup(table_ref, key) do
+    case :ets.lookup(table_ref, key) do
+      [{_, pid}] ->
+        {:ok, pid}
+
+      _ ->
+        {:error, :missing_subscription}
+    end
+  end
+end

--- a/test/ib_ex/client/messages/account_data/account_detail_test.exs
+++ b/test/ib_ex/client/messages/account_data/account_detail_test.exs
@@ -1,11 +1,16 @@
 defmodule IbEx.Client.Messages.AccountData.AccountDetailTest do
   use ExUnit.Case, async: true
+
   alias IbEx.Client.Messages.AccountData.AccountDetail
+
+  alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Subscriptions
+
+  @valid_fields ["1", "NetLiquidation", "100000", "USD", "MYACCT123"]
 
   describe "from_fields/1" do
     test "successfully parses a valid list into an AccountDetail struct" do
-      assert {:ok, %AccountDetail{} = msg} =
-               AccountDetail.from_fields(["1", "NetLiquidation", "100000", "USD", "MYACCT123"])
+      assert {:ok, %AccountDetail{} = msg} = AccountDetail.from_fields(@valid_fields)
 
       assert msg.version == 1
       assert msg.field == "NetLiquidation"
@@ -26,10 +31,23 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetailTest do
 
   describe "Inspect" do
     test "inspect/2 returns a human-readable version of the message" do
-      {:ok, msg} = AccountDetail.from_fields(["1", "EquityWithLoanValue", "50000", "EUR", "ACCT456"])
+      {:ok, msg} = AccountDetail.from_fields(@valid_fields)
 
       assert inspect(msg) ==
-               "<-- AccountDetail{field: EquityWithLoanValue, value: 50000, currency: EUR, account: ACCT456}"
+               "<-- AccountDetail{field: NetLiquidation, value: 100000, currency: USD, account: MYACCT123}"
+    end
+  end
+
+  describe "Subscribable" do
+    test "looks up the message in the subscriptions mapping" do
+      table_ref = Subscriptions.initialize()
+      Subscriptions.subscribe_by_modules(table_ref, [AccountDetail], self())
+
+      {:ok, msg} = AccountDetail.from_fields(@valid_fields)
+
+      assert {:ok, pid} = Subscribable.lookup(msg, table_ref)
+
+      assert pid == self()
     end
   end
 end

--- a/test/ib_ex/client/messages/account_data/account_download_end_test.exs
+++ b/test/ib_ex/client/messages/account_data/account_download_end_test.exs
@@ -1,6 +1,9 @@
 defmodule IbEx.Client.Messages.AccountData.AccountDownloadEndTest do
   use ExUnit.Case, async: true
+
   alias IbEx.Client.Messages.AccountData.AccountDownloadEnd
+  alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
     test "successfully parses a valid list into an AccountDownloadEnd struct" do
@@ -22,6 +25,19 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEndTest do
     test "inspect/2 returns a human-readable version of the message" do
       {:ok, msg} = AccountDownloadEnd.from_fields(["3", "ACCT456"])
       assert inspect(msg) == "<-- AccountDownloadEnd{account: ACCT456}"
+    end
+  end
+
+  describe "Subscribable" do
+    test "looks up the message in the subscriptions mapping" do
+      table_ref = Subscriptions.initialize()
+      Subscriptions.subscribe_by_modules(table_ref, [AccountDownloadEnd], self())
+
+      {:ok, msg} = AccountDownloadEnd.from_fields(["2", "MYACCT123"])
+
+      assert {:ok, pid} = Subscribable.lookup(msg, table_ref)
+
+      assert pid == self()
     end
   end
 end

--- a/test/ib_ex/client/messages/account_data/account_update_time_test.exs
+++ b/test/ib_ex/client/messages/account_data/account_update_time_test.exs
@@ -1,6 +1,9 @@
 defmodule IbEx.Client.Messages.AccountData.AccountUpdateTimeTest do
   use ExUnit.Case, async: true
+
   alias IbEx.Client.Messages.AccountData.AccountUpdateTime
+  alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
     test "parses valid inputs into an AccountUpdateTime struct" do
@@ -30,6 +33,19 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTimeTest do
 
       expected_output = "<-- AccountUpdateTime{timestamp: #{ts}}"
       assert inspect(msg) == expected_output
+    end
+  end
+
+  describe "Subscribable" do
+    test "looks up the message in the subscriptions mapping" do
+      table_ref = Subscriptions.initialize()
+      Subscriptions.subscribe_by_modules(table_ref, [AccountUpdateTime], self())
+
+      {:ok, msg} = AccountUpdateTime.from_fields(["1", "10:47"])
+
+      assert {:ok, pid} = Subscribable.lookup(msg, table_ref)
+
+      assert pid == self()
     end
   end
 end

--- a/test/ib_ex/client/messages/account_data/request_test.exs
+++ b/test/ib_ex/client/messages/account_data/request_test.exs
@@ -2,6 +2,12 @@ defmodule IbEx.Client.Messages.AccountData.RequestTest do
   use ExUnit.Case
 
   alias IbEx.Client.Messages.AccountData.Request
+  alias IbEx.Client.Messages.AccountData.AccountDetail
+  alias IbEx.Client.Messages.AccountData.AccountDownloadEnd
+  alias IbEx.Client.Messages.AccountData.AccountUpdateTime
+
+  alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Subscriptions
 
   describe "new/2" do
     test "returns an AccountData Request struct" do
@@ -26,6 +32,25 @@ defmodule IbEx.Client.Messages.AccountData.RequestTest do
 
       # Adjust this expected string to the format that your Inspect implementation produces.
       assert inspect(msg) == "--> AccountUpdates{message_id: 6, subscribe: true, account_code: nil}"
+    end
+  end
+
+  describe "Subscribable" do
+    test "subscribe/2 subscribes the response message modules to the given pid" do
+      table_ref = Subscriptions.initialize()
+
+      {:ok, msg} = Request.new(true)
+
+      assert {:ok, _msg} = Subscribable.subscribe(msg, self(), table_ref)
+
+      assert {:ok, pid} = Subscriptions.lookup(table_ref, AccountDetail)
+      assert pid == self()
+
+      assert {:ok, pid} = Subscriptions.lookup(table_ref, AccountDownloadEnd)
+      assert pid == self()
+
+      assert {:ok, pid} = Subscriptions.lookup(table_ref, AccountUpdateTime)
+      assert pid == self()
     end
   end
 end

--- a/test/ib_ex/client/messages/matching_symbols/request_test.exs
+++ b/test/ib_ex/client/messages/matching_symbols/request_test.exs
@@ -2,12 +2,13 @@ defmodule IbEx.Client.Messages.MatchingSymbols.RequestTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MatchingSymbols.Request
+  alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Subscriptions
 
   describe "new/1" do
     test "returns a MatchingSymbols Request message" do
-      assert {:ok, %Request{} = request} = Request.new(pattern: "AAPL", request_id: 1)
+      assert {:ok, %Request{} = request} = Request.new("AAPL")
 
-      assert request.request_id == 1
       assert request.pattern == "AAPL"
       assert request.message_id == 81
     end
@@ -15,7 +16,8 @@ defmodule IbEx.Client.Messages.MatchingSymbols.RequestTest do
 
   describe "String.Chars" do
     test "to_string/1 returns the binary representation of the message" do
-      {:ok, msg} = Request.new(pattern: "AAPL", request_id: 1)
+      {:ok, msg} = Request.new("AAPL")
+      msg = %{msg | request_id: 1}
 
       assert to_string(msg) == <<56, 49, 0, 49, 0, 65, 65, 80, 76, 0>>
     end
@@ -23,9 +25,25 @@ defmodule IbEx.Client.Messages.MatchingSymbols.RequestTest do
 
   describe "Inspect" do
     test "inspect/2 returns a human-readable version of the message" do
-      {:ok, msg} = Request.new(pattern: "AAPL", request_id: 1)
+      {:ok, msg} = Request.new("AAPL")
+      msg = %{msg | request_id: 1}
 
       assert inspect(msg) == "--> MatchingSymbols{id: 81, request_id: 1, pattern: AAPL}"
+    end
+  end
+
+  describe "Subscribable" do
+    test "subscribe/2 subscribes incoming messages with the msg's request id to the given pid" do
+      table_ref = Subscriptions.initialize()
+
+      {:ok, msg} = Request.new("AAPL")
+
+      assert {:ok, msg} = Subscribable.subscribe(msg, self(), table_ref)
+      assert msg.request_id == 1
+
+      assert {:ok, pid} = Subscriptions.lookup(table_ref, to_string(msg.request_id))
+
+      assert pid == self()
     end
   end
 end

--- a/test/ib_ex/client/messages/matching_symbols/symbol_samples_test.exs
+++ b/test/ib_ex/client/messages/matching_symbols/symbol_samples_test.exs
@@ -2,8 +2,10 @@ defmodule IbEx.Client.Messages.MatchingSymbols.SymbolSamplesTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MatchingSymbols.SymbolSamples
+  alias IbEx.Client.Protocols.Subscribable
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Types.ContractDescription
+  alias IbEx.Client.Subscriptions
 
   @valid_fields [
     "1",
@@ -72,6 +74,19 @@ defmodule IbEx.Client.Messages.MatchingSymbols.SymbolSamplesTest do
     @tag capture_log: true
     test "returns invalid args when called with a list in a different format" do
       assert {:error, :invalid_args} == SymbolSamples.from_fields(["1", "2", "3"])
+    end
+  end
+
+  describe "Subscribable" do
+    test "looks up the message in the subscriptions mapping" do
+      table_ref = Subscriptions.initialize()
+      Subscriptions.subscribe_by_request_id(table_ref, self())
+
+      {:ok, msg} = SymbolSamples.from_fields(@valid_fields)
+
+      assert {:ok, pid} = Subscribable.lookup(msg, table_ref)
+
+      assert pid == self()
     end
   end
 end

--- a/test/ib_ex/client_test.exs
+++ b/test/ib_ex/client_test.exs
@@ -1,7 +1,59 @@
 defmodule IbEx.ClientTest do
   use ExUnit.Case, async: true
 
+  defmodule MockSuccessConnection do
+    use GenServer
+
+    def start_link(_) do
+      GenServer.start_link(__MODULE__, [])
+    end
+
+    @impl true
+    def init(arg) do
+      {:ok, arg}
+    end
+
+    def send_message(_pid, _msg) do
+      :ok
+    end
+
+    @impl true
+    def handle_call(_, _, state) do
+      {:reply, :ok, state}
+    end
+  end
+
+  defmodule MockFailedConnection do
+    def start_link(_) do
+      {:error, :timeout}
+    end
+  end
+
   alias IbEx.Client
+  alias IbEx.Client.Messages.MatchingSymbols.Request
+  alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Types.ContractDescription
+  alias IbEx.Client.Subscriptions
+
+  alias __MODULE__.MockSuccessConnection
+  alias __MODULE__.MockFailedConnection
+
+  describe "init/1" do
+    test "opens the connection to IBKR's TWS or Gateway and creates the message subscriptions table" do
+      assert {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      assert is_pid(state.connection)
+      assert Process.alive?(state.connection)
+
+      refute is_nil(state.subscriptions_table_ref)
+
+      assert :ets.lookup(state.subscriptions_table_ref, :message_request_ids) == [message_request_ids: 1]
+    end
+
+    test "stops the server on failure to open the connection" do
+      assert {:stop, {:connection_error, {:error, :timeout}}} = Client.init(connection_handler: MockFailedConnection)
+    end
+  end
 
   describe "handle_cast/2 when processing an incoming message" do
     test "updates the client's state with the server version, the connection timestamp and continues to validate the server version" do
@@ -16,6 +68,57 @@ defmodule IbEx.ClientTest do
       assert new_state.status == :connected
 
       assert continuation == {:continue, :validate_server_version}
+    end
+
+    @symbol_samples_msg_str <<55, 57, 0, 49, 0, 49, 55, 0, 50, 54, 53, 53, 57, 56, 0, 65, 65, 80, 76, 0, 83, 84, 75, 0,
+                              78, 65, 83, 68, 65, 81, 0, 85, 83, 68, 0, 53, 0, 67, 70, 68, 0, 79, 80, 84, 0, 73, 79, 80,
+                              84, 0, 87, 65, 82, 0, 66, 65, 71, 0, 65, 80, 80, 76, 69, 32, 73, 78, 67, 0, 0, 52, 57, 51,
+                              53, 52, 54, 48, 52, 56, 0, 65, 65, 80, 76, 0, 83, 84, 75, 0, 76, 83, 69, 69, 84, 70, 0,
+                              71, 66, 80, 0, 48, 0, 76, 83, 32, 49, 88, 32, 65, 65, 80, 76, 0, 0>>
+
+    @tag capture_log: true
+    test "relays the msg when there's a subscription for said message" do
+      table_ref = Subscriptions.initialize()
+      Subscriptions.subscribe_by_request_id(table_ref, self())
+
+      state = %{
+        subscriptions_table_ref: table_ref,
+        status: :connected
+      }
+
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, @symbol_samples_msg_str}, state)
+
+      assert_received {:"$gen_cast", {:message_received, msg}}
+
+      assert msg.request_id == "1"
+      assert length(msg.contracts) == 2
+
+      first_contract = List.first(msg.contracts)
+
+      assert first_contract == %ContractDescription{
+               contract: %Contract{
+                 conid: "265598",
+                 symbol: "AAPL",
+                 security_type: "STK",
+                 currency: "USD",
+                 primary_exchange: "NASDAQ",
+                 description: "APPLE INC",
+                 issuer_id: ""
+               },
+               derivative_security_types: ["CFD", "OPT", "IOPT", "WAR", "BAG"]
+             }
+    end
+  end
+
+  describe "handle_cast/2 when sending an outgoing message" do
+    test "subscribes the message's responses to the subscriptions mapping" do
+      assert {:ok, msg} = Request.new("AAPL")
+
+      assert {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      assert {:noreply, ^state} = Client.handle_cast({:send_request, self(), msg}, state)
+
+      assert [{"1", pid}] = :ets.lookup(state.subscriptions_table_ref, "1")
+      assert pid == self()
     end
   end
 end


### PR DESCRIPTION
* Relays message responses back to the process that built the request message
* Implements an ETS table for message subscriptions with 2 strategies:
  * `request_id`-based for request messages that have a `request_id` field
  * Module-based for messages without a `request_id` field.
* Refactors the `AccountDetails.Request` message to use the module-based subscription mechanism as well as its response messages
* Refactors the `MatchingSymbols.Request` message to use the `request_id`-based mechanism as well as its `MatchingSymbols.SymbolSamples` response message