### PR TITLE
[FEAT-67] Implement Request Market Data Type message

### DIFF
--- a/lib/ib_ex/client/messages/market_data/market_data_type.ex
+++ b/lib/ib_ex/client/messages/market_data/market_data_type.ex
@@ -35,6 +35,24 @@ defmodule IbEx.Client.Messages.MarketData.MarketDataType do
     end
   end
 
+  def atom_to_integer(data_type_atom) do
+    case data_type_atom do
+      :live -> 1
+      :frozen -> 2
+      :delayed -> 3
+      :delayed_frozen -> 4
+    end
+  end
+
+  def integer_to_atom(data_type_integer) do
+    case data_type_integer do
+      1 -> :live
+      2 -> :frozen
+      3 -> :delayed
+      4 -> :delayed_frozen
+    end
+  end
+
   defimpl Inspect, for: __MODULE__ do
     def inspect(msg, _opts) do
       "<-- %MarketData.MarketDataType{request_id: #{msg.request_id}, data_type: #{msg.data_type}}"

--- a/lib/ib_ex/client/messages/market_data/request_market_data_type.ex
+++ b/lib/ib_ex/client/messages/market_data/request_market_data_type.ex
@@ -1,0 +1,91 @@
+defmodule IbEx.Client.Messages.MarketData.RequestMarketDataType do
+  @moduledoc """
+  Request to switch market data type 
+
+
+  The input parameters are the following:
+
+  * market_data_type: type of market data to retrieve. Possible values: 
+    - :live
+    - :frozen
+    - :delayed
+    - :delayed_frozen
+
+  """
+
+  @version 1
+
+  defstruct message_id: nil,
+            request_id: nil,
+            version: @version,
+            market_data_type: :live
+
+  alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Messages.MarketData.MarketDataType
+
+  @type t :: %__MODULE__{
+          message_id: non_neg_integer(),
+          request_id: non_neg_integer(),
+          version: non_neg_integer(),
+          market_data_type: 1..4
+        }
+
+  @spec new(non_neg_integer(), :live | :frozen | :delayed | :delayed_frozen) ::
+          {:ok, t()} | {:error, :not_implemented}
+  def new(request_id, market_data_type) do
+    case Requests.message_id_for(__MODULE__) do
+      {:ok, message_id} ->
+        {
+          :ok,
+          %__MODULE__{
+            message_id: message_id,
+            request_id: request_id,
+            market_data_type: MarketDataType.atom_to_integer(market_data_type)
+          }
+        }
+
+      :error ->
+        {:error, :not_implemented}
+    end
+  end
+
+  defimpl String.Chars, for: __MODULE__ do
+    alias IbEx.Client.Messages.Base
+
+    def to_string(msg) do
+      fields = [
+        msg.message_id,
+        msg.version
+      ]
+
+      Base.build(fields)
+    end
+  end
+
+  defimpl Inspect, for: __MODULE__ do
+    alias IbEx.Client.Messages.MarketData.MarketDataType
+
+    def inspect(msg, _opts) do
+      """
+      --> MarketData.RequestMarketDataType{
+        request_id: #{msg.request_id},
+        market_data_type: :#{MarketDataType.integer_to_atom(msg.market_data_type)}
+      }
+      """
+    end
+  end
+
+  defimpl IbEx.Client.Protocols.Subscribable, for: __MODULE__ do
+    alias IbEx.Client.Subscriptions
+
+    # Subscription based on request_id, can handle multiple requests
+    def subscribe(msg, pid, table_ref) do
+      request_id = Subscriptions.subscribe_by_request_id(table_ref, pid)
+      {:ok, %{msg | request_id: request_id}}
+    end
+
+    def lookup(_, _) do
+      {:error, :lookup_not_necessary}
+    end
+  end
+end

--- a/lib/ib_ex/client/messages/market_data/request_market_data_type.ex
+++ b/lib/ib_ex/client/messages/market_data/request_market_data_type.ex
@@ -30,16 +30,15 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataType do
           market_data_type: 1..4
         }
 
-  @spec new(non_neg_integer(), :live | :frozen | :delayed | :delayed_frozen) ::
+  @spec new(:live | :frozen | :delayed | :delayed_frozen) ::
           {:ok, t()} | {:error, :not_implemented}
-  def new(request_id, market_data_type) do
+  def new(market_data_type) do
     case Requests.message_id_for(__MODULE__) do
       {:ok, message_id} ->
         {
           :ok,
           %__MODULE__{
             message_id: message_id,
-            request_id: request_id,
             market_data_type: MarketDataType.atom_to_integer(market_data_type)
           }
         }
@@ -68,7 +67,6 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataType do
     def inspect(msg, _opts) do
       """
       --> MarketData.RequestMarketDataType{
-        request_id: #{msg.request_id},
         market_data_type: :#{MarketDataType.integer_to_atom(msg.market_data_type)}
       }
       """
@@ -84,8 +82,8 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataType do
       {:ok, %{msg | request_id: request_id}}
     end
 
-    def lookup(_, _) do
-      {:error, :lookup_not_necessary}
+    def lookup(msg, table_ref) do
+      Subscriptions.lookup(table_ref, to_string(msg.request_id))
     end
   end
 end

--- a/lib/ib_ex/client/messages/requests.ex
+++ b/lib/ib_ex/client/messages/requests.ex
@@ -37,7 +37,7 @@ defmodule IbEx.Client.Messages.Requests do
     "cancel_calculated_implied_volatility" => 56,
     "cancel_calculated_option_price" => 57,
     "global_cancel" => 58,
-    "market_data_type" => 59,
+    Messages.MarketData.RequestMarketDataType => 59,
     "positions" => 61,
     "account_summary" => 62,
     "cancel_account_summary" => 63,

--- a/test/ib_ex/client/messages/market_data/market_data_type_test.exs
+++ b/test/ib_ex/client/messages/market_data/market_data_type_test.exs
@@ -37,6 +37,22 @@ defmodule IbEx.Client.Messages.MarketData.MarketDataTypeTest do
     end
   end
 
+  describe "maps market data type atoms to integers and vice versa" do
+    test "atom_to_integer/1" do
+      assert MarketDataType.atom_to_integer(:live) == 1
+      assert MarketDataType.atom_to_integer(:frozen) == 2
+      assert MarketDataType.atom_to_integer(:delayed) == 3
+      assert MarketDataType.atom_to_integer(:delayed_frozen) == 4
+    end
+
+    test "integer_to_atom/1" do
+      assert MarketDataType.integer_to_atom(1) == :live
+      assert MarketDataType.integer_to_atom(2) == :frozen
+      assert MarketDataType.integer_to_atom(3) == :delayed
+      assert MarketDataType.integer_to_atom(4) == :delayed_frozen
+    end
+  end
+
   describe "Inspect implementation" do
     test "inspects MarketDataType struct correctly" do
       msg = %MarketDataType{request_id: 9001, data_type: :live}

--- a/test/ib_ex/client/messages/market_data/request_market_data_type_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_market_data_type_test.exs
@@ -1,0 +1,46 @@
+defmodule IbEx.Client.Messages.MarketData.RequestMarketDataTypeTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Messages.MarketData.RequestMarketDataType
+  alias IbEx.Client.Messages.MarketData.MarketDataType
+
+  describe "new/2" do
+    test "creates the message with valid inputs" do
+      assert {:ok, msg} = RequestMarketDataType.new(123, :delayed)
+
+      assert msg.message_id == 59
+      assert msg.request_id == 123
+      assert msg.market_data_type == 3
+    end
+  end
+
+  describe "String.Chars implementation" do
+    test "converts the message to a serializable string" do
+      msg = %RequestMarketDataType{
+        message_id: 59,
+        request_id: 123,
+        market_data_type: 3
+      }
+
+      assert to_string(msg) == <<53, 57, 0, 49, 0>>
+    end
+  end
+
+  describe "Inspect implementation" do
+    test "returns a human-readable version of the struct" do
+      msg = %RequestMarketDataType{
+        message_id: 59,
+        request_id: 123,
+        market_data_type: 3
+      }
+
+      assert inspect(msg) ==
+               """
+               --> MarketData.RequestMarketDataType{
+                 request_id: #{msg.request_id},
+                 market_data_type: :#{MarketDataType.integer_to_atom(msg.market_data_type)}
+               }
+               """
+    end
+  end
+end

--- a/test/ib_ex/client/messages/market_data/request_market_data_type_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_market_data_type_test.exs
@@ -1,15 +1,16 @@
 defmodule IbEx.Client.Messages.MarketData.RequestMarketDataTypeTest do
   use ExUnit.Case, async: true
 
+  alias IbEx.Client.Protocols.Subscribable
   alias IbEx.Client.Messages.MarketData.RequestMarketDataType
   alias IbEx.Client.Messages.MarketData.MarketDataType
+  alias IbEx.Client.Subscriptions
 
-  describe "new/2" do
+  describe "new/1" do
     test "creates the message with valid inputs" do
-      assert {:ok, msg} = RequestMarketDataType.new(123, :delayed)
+      assert {:ok, msg} = RequestMarketDataType.new(:delayed)
 
       assert msg.message_id == 59
-      assert msg.request_id == 123
       assert msg.market_data_type == 3
     end
   end
@@ -18,7 +19,6 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataTypeTest do
     test "converts the message to a serializable string" do
       msg = %RequestMarketDataType{
         message_id: 59,
-        request_id: 123,
         market_data_type: 3
       }
 
@@ -30,17 +30,26 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataTypeTest do
     test "returns a human-readable version of the struct" do
       msg = %RequestMarketDataType{
         message_id: 59,
-        request_id: 123,
         market_data_type: 3
       }
 
       assert inspect(msg) ==
                """
                --> MarketData.RequestMarketDataType{
-                 request_id: #{msg.request_id},
                  market_data_type: :#{MarketDataType.integer_to_atom(msg.market_data_type)}
                }
                """
+    end
+  end
+
+  describe "Subscribable" do
+    test "subscribes the message" do
+      pid = self()
+      table_ref = Subscriptions.initialize()
+      {:ok, msg} = RequestMarketDataType.new(:delayed)
+      {:ok, subscribed_msg} = Subscribable.subscribe(msg, pid, table_ref)
+
+      assert {:ok, ^pid} = Subscribable.lookup(subscribed_msg, table_ref)
     end
   end
 end


### PR DESCRIPTION
Implemented `RequestMarketDataType` message ([TWS API docs](https://www.interactivebrokers.com/campus/ibkr-api-page/twsapi-doc/#md-type-behavior)). 

- put `version: 1` as per Python API source code 

Sent the request to IB Gateway it worked 👍

Let me know what you think please. 

Cheers