### PR TITLE
42 type request historical data

### DIFF
--- a/lib/ib_ex/client/messages/market_data/request_historical_data.ex
+++ b/lib/ib_ex/client/messages/market_data/request_historical_data.ex
@@ -75,9 +75,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalData do
          {:ok, end_date_time} <- format_end_date_time(end_date_time),
          {:ok, duration} <- Durations.format(duration),
          {:ok, bar_size} <- BarSizes.format(bar_size),
-         {:ok, what_to_show} <- WhatToShow.format(what_to_show),
-         {:ok, use_rth} <- Utils.bool_to_int(use_rth),
-         {:ok, keep_up_to_date} <- Utils.bool_to_int(keep_up_to_date) do
+         {:ok, what_to_show} <- WhatToShow.format(what_to_show) do
       {
         :ok,
         %__MODULE__{

--- a/lib/ib_ex/client/messages/market_data/request_historical_data.ex
+++ b/lib/ib_ex/client/messages/market_data/request_historical_data.ex
@@ -45,9 +45,9 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalData do
           request_id: non_neg_integer(),
           contract: Contract.t(),
           end_date_time: end_date_time_type(),
-          duration: Durations.t(),
-          bar_size: BarSizes.t(),
-          what_to_show: WhatToShow.t(),
+          duration: String.t(),
+          bar_size: String.t(),
+          what_to_show: String.t(),
           use_rth: boolean(),
           keep_up_to_date: boolean()
         }

--- a/lib/ib_ex/client/messages/market_data/request_historical_data.ex
+++ b/lib/ib_ex/client/messages/market_data/request_historical_data.ex
@@ -36,7 +36,6 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalData do
   alias IbEx.Client.Constants.{WhatToShow, BarSizes, Durations}
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.Contract
-  alias IbEx.Client.Utils
 
   @type end_date_time_type :: DateTime.t() | nil
   @type t :: %__MODULE__{

--- a/lib/ib_ex/client/utils.ex
+++ b/lib/ib_ex/client/utils.ex
@@ -95,8 +95,4 @@ defmodule IbEx.Client.Utils do
   def parse_timestamp_str(_, _, _) do
     {:error, :invalid_args}
   end
-
-  @spec bool_to_int(boolean()) :: {:ok, 0..1} | {:error, :invalid_args}
-  def bool_to_int(value) when not is_boolean(value), do: {:error, :invalid_args}
-  def bool_to_int(value), do: {:ok, (value && 1) || 0}
 end

--- a/test/ib_ex/client/messages/market_data/request_historical_data_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_historical_data_test.exs
@@ -38,9 +38,9 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
       assert msg.duration == "1 W"
       assert msg.bar_size == "1 hour"
       assert msg.what_to_show == "TRADES"
-      assert msg.use_rth == 0
+      assert msg.use_rth == false
       assert msg.format_date == 2
-      assert msg.keep_up_to_date == 0
+      assert msg.keep_up_to_date == false
     end
 
     test "creates the message with valid date and time" do
@@ -57,9 +57,9 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
       assert msg.duration == "1 W"
       assert msg.bar_size == "1 hour"
       assert msg.what_to_show == "TRADES"
-      assert msg.use_rth == 0
+      assert msg.use_rth == false
       assert msg.format_date == 2
-      assert msg.keep_up_to_date == 0
+      assert msg.keep_up_to_date == false
     end
   end
 
@@ -92,8 +92,8 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
         duration: "1 W",
         bar_size: "1 hour",
         what_to_show: "TRADES",
-        use_rth: 0,
-        keep_up_to_date: 0
+        use_rth: false,
+        keep_up_to_date: false
       }
 
       contract_str = Enum.join(Contract.serialize(@contract, false), ", ")
@@ -107,9 +107,9 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
                  duration: 1 W, 
                  bar_size: 1 hour,
                  what_to_show: TRADES,
-                 use_rth: 0,
+                 use_rth: false,
                  format_date: 2,
-                 keep_up_to_date: 0
+                 keep_up_to_date: false
                }
                """
     end

--- a/test/ib_ex/client/utils_test.exs
+++ b/test/ib_ex/client/utils_test.exs
@@ -83,15 +83,4 @@ defmodule IbEx.Client.UtilsTest do
       assert is_nil(Utils.to_bool("-1"))
     end
   end
-
-  describe "bool_to_int/1" do
-    test "converts false to 0 and true to 1" do
-      assert Utils.bool_to_int(false) == {:ok, 0}
-      assert Utils.bool_to_int(true) == {:ok, 1}
-    end
-
-    test "returns :invalid_args for bad arguments" do
-      assert Utils.bool_to_int(:not_a_bool) == {:error, :invalid_args}
-    end
-  end
 end


### PR DESCRIPTION
- fixes `RequestHistoricalData.t()` 
- removes unnecessary `bool_to_int` 