### PR TITLE
[FEAT-29] implement Subscribable for Create/CancelOrder requests

### DIFF
--- a/test/ib_ex/client/messages/orders/request_cancel_order_test.exs
+++ b/test/ib_ex/client/messages/orders/request_cancel_order_test.exs
@@ -6,17 +6,6 @@ defmodule IbEx.Client.Messages.Orders.RequestCancelOrderTest do
   alias IbEx.Client.Protocols.Subscribable
   alias IbEx.Client.Subscriptions
 
-  describe "new/0" do
-    test "creates a RequestCancelOrder struct" do
-      assert {:ok, msg} = RequestCancelOrder.new()
-
-      assert msg.message_id == 4
-      assert msg.version == 1
-      assert msg.order_id == nil
-      assert msg.order_cancel_params == OrderCancel.new()
-    end
-  end
-
   describe "new/1" do
     test "creates a RequestCancelOrder struct with order_id" do
       order_id = 123
@@ -75,10 +64,10 @@ defmodule IbEx.Client.Messages.Orders.RequestCancelOrderTest do
     test "subscribe/2 unsubscribes incoming messages with the given request id to the given pid" do
       table_ref = Subscriptions.initialize()
       :ets.insert(table_ref, {"1", self()})
-      {:ok, msg} = RequestCancelOrder.new()
+      {:ok, msg} = RequestCancelOrder.new(123)
 
       assert {:ok, msg} = Subscribable.subscribe(msg, self(), table_ref)
-      assert msg.order_id == "1"
+      assert msg.request_id == "1"
 
       assert {:error, :missing_subscription} == Subscriptions.reverse_lookup(table_ref, self())
     end

--- a/test/ib_ex/client/messages/orders/request_create_order_test.exs
+++ b/test/ib_ex/client/messages/orders/request_create_order_test.exs
@@ -3,6 +3,8 @@ defmodule IbEx.Client.Messages.Orders.RequestCreateOrderTest do
 
   alias IbEx.Client.Types.{Order, Contract}
   alias IbEx.Client.Messages.Orders.RequestCreateOrder
+  alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Subscriptions
 
   @order_id 123
   @order Order.new(%{
@@ -61,6 +63,16 @@ defmodule IbEx.Client.Messages.Orders.RequestCreateOrderTest do
                  contract: #{contract_str}
                }
                """
+    end
+  end
+
+  describe "Subscribable" do
+    test "subscribes the message" do
+      pid = self()
+      table_ref = Subscriptions.initialize()
+      {:ok, msg} = RequestCreateOrder.new(@order_id, @order, @contract)
+      {:ok, subscribed_msg} = Subscribable.subscribe(msg, pid, table_ref)
+      assert {:ok, ^pid} = Subscribable.lookup(subscribed_msg, table_ref)
     end
   end
 end


### PR DESCRIPTION
- adds `Subscribable` implementation
- removes unused function

closes #29 