### PR TITLE
[FEAT-155] Swap Inspect implementation for a custom protocol to trace messages flow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,9 +22,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
-      uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.17' # [Required] Define the Elixir version
+        elixir-version: '1.18' # [Required] Define the Elixir version
         otp-version: '27.0'      # [Required] Define the Erlang/OTP version
     - name: Restore dependencies cache
       uses: actions/cache@v3

--- a/lib/ib_ex/client/connection.ex
+++ b/lib/ib_ex/client/connection.ex
@@ -70,7 +70,6 @@ defmodule IbEx.Client.Connection do
 
   @impl true
   def handle_call({:send_message, msg}, _from, state) do
-    Logger.info("#{inspect(msg)}")
     Socket.send_message(state.socket, to_string(msg))
 
     {:reply, :ok, state}

--- a/lib/ib_ex/client/messages/account_data/account_detail.ex
+++ b/lib/ib_ex/client/messages/account_data/account_detail.ex
@@ -72,6 +72,7 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetail do
   defstruct version: nil, field: nil, value: nil, currency: nil, account: nil
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields([version_str, field, value, currency, account]) do
     case Integer.parse(version_str) do
@@ -96,8 +97,8 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetail do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- AccountDetail{field: #{msg.field}, value: #{msg.value}, currency: #{msg.currency}, account: #{msg.account}}"
     end
   end

--- a/lib/ib_ex/client/messages/account_data/account_download_end.ex
+++ b/lib/ib_ex/client/messages/account_data/account_download_end.ex
@@ -6,6 +6,7 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEnd do
   defstruct version: nil, account: nil
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields([version_str, account]) do
     case Integer.parse(version_str) do
@@ -27,8 +28,8 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEnd do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- AccountDownloadEnd{account: #{msg.account}}"
     end
   end

--- a/lib/ib_ex/client/messages/account_data/account_update_time.ex
+++ b/lib/ib_ex/client/messages/account_data/account_update_time.ex
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTime do
   defstruct version: nil, timestamp: nil
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @spec from_fields([String.t()]) :: {:ok, %__MODULE__{}} | {:error, :invalid_args}
   def from_fields([version_str, hour_minute]) do
@@ -32,8 +33,8 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTime do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- AccountUpdateTime{timestamp: #{msg.timestamp}}"
     end
   end

--- a/lib/ib_ex/client/messages/account_data/request.ex
+++ b/lib/ib_ex/client/messages/account_data/request.ex
@@ -79,6 +79,7 @@ defmodule IbEx.Client.Messages.AccountData.Request do
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, version: @message_version, subscribe: nil, account_code: nil
 
@@ -115,8 +116,8 @@ defmodule IbEx.Client.Messages.AccountData.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> AccountUpdates{message_id: #{msg.message_id}, subscribe: #{msg.subscribe}, account_code: #{inspect(msg.account_code)}}"
     end
   end

--- a/lib/ib_ex/client/messages/current_time/request.ex
+++ b/lib/ib_ex/client/messages/current_time/request.ex
@@ -9,6 +9,7 @@ defmodule IbEx.Client.Messages.CurrentTime.Request do
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @message_version 1
 
@@ -37,8 +38,8 @@ defmodule IbEx.Client.Messages.CurrentTime.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> %CurrentTime{id: #{msg.id}, version: #{msg.version}}"
     end
   end

--- a/lib/ib_ex/client/messages/current_time/response.ex
+++ b/lib/ib_ex/client/messages/current_time/response.ex
@@ -5,6 +5,7 @@ defmodule IbEx.Client.Messages.CurrentTime.Response do
   defstruct version: nil, timestamp: nil
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields([version_str, epoch_str]) do
     with {version, _} <- Integer.parse(version_str),
@@ -21,8 +22,8 @@ defmodule IbEx.Client.Messages.CurrentTime.Response do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %CurrentTime{version: #{msg.version}, timestamp: #{msg.timestamp}}
       """

--- a/lib/ib_ex/client/messages/error_info/error.ex
+++ b/lib/ib_ex/client/messages/error_info/error.ex
@@ -1,8 +1,10 @@
 defmodule IbEx.Client.Messages.ErrorInfo.Error do
   defstruct id: nil, code: nil, version: nil, message: nil
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  alias IbEx.Client.Protocols.Traceable
+
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %Error{id: #{msg.id}, code: #{msg.code}, version: #{msg.version}, message: #{msg.message}}
       """

--- a/lib/ib_ex/client/messages/error_info/info.ex
+++ b/lib/ib_ex/client/messages/error_info/info.ex
@@ -1,8 +1,10 @@
 defmodule IbEx.Client.Messages.ErrorInfo.Info do
   defstruct id: nil, code: nil, version: nil, message: nil
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  alias IbEx.Client.Protocols.Traceable
+
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %Info{id: #{msg.id}, code: #{msg.code}, version: #{msg.version}, message: #{msg.message}}
       """

--- a/lib/ib_ex/client/messages/executions/commission_report.ex
+++ b/lib/ib_ex/client/messages/executions/commission_report.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.Executions.CommissionReport do
             yield_redemption_date: nil
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields(fields) when length(fields) == 7 do
     [version, exec_id, commission, currency, realized, yield, redemption_date] = fields
@@ -29,8 +30,8 @@ defmodule IbEx.Client.Messages.Executions.CommissionReport do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
         <-- CommissionReport{
             version: #{msg.version},

--- a/lib/ib_ex/client/messages/executions/execution_data.ex
+++ b/lib/ib_ex/client/messages/executions/execution_data.ex
@@ -6,6 +6,7 @@ defmodule IbEx.Client.Messages.Executions.ExecutionData do
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Types.Execution
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct request_id: nil, contract: nil, execution: nil
 
@@ -41,8 +42,8 @@ defmodule IbEx.Client.Messages.Executions.ExecutionData do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- ExecutionData{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/executions/execution_data_end.ex
+++ b/lib/ib_ex/client/messages/executions/execution_data_end.ex
@@ -9,6 +9,7 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataEnd do
 
   alias IbEx.Client.Utils
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @spec from_fields(list(String.t())) :: {:ok, t()} | {:error, :invalid_args}
   def from_fields([version_str, request_id]) do
@@ -20,8 +21,8 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataEnd do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- ExecutionDataEnd{version: #{msg.version}, request_id: #{msg.request_id}}
       """

--- a/lib/ib_ex/client/messages/executions/request.ex
+++ b/lib/ib_ex/client/messages/executions/request.ex
@@ -14,6 +14,7 @@ defmodule IbEx.Client.Messages.Executions.Request do
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.ExecutionsFilter
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @version 3
 
@@ -63,8 +64,8 @@ defmodule IbEx.Client.Messages.Executions.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> Executions.Request{
         message_id: #{msg.message_id},

--- a/lib/ib_ex/client/messages/historical_ticks/last.ex
+++ b/lib/ib_ex/client/messages/historical_ticks/last.ex
@@ -5,6 +5,8 @@ defmodule IbEx.Client.Messages.HistoricalTicks.Last do
 
   alias IbEx.Client.Types.Trade
 
+  # TODO: Implement Traceable for this message
+
   def from_fields([request_id, _amount_of_ticks | ticks_fields]) do
     trades =
       ticks_fields

--- a/lib/ib_ex/client/messages/historical_ticks/request.ex
+++ b/lib/ib_ex/client/messages/historical_ticks/request.ex
@@ -1,6 +1,7 @@
 defmodule IbEx.Client.Messages.HistoricalTicks.Request do
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Protocols.Traceable
 
   @valid_what_to_show ["TRADES", "BID_ASK", "MIDPOINT"]
 
@@ -84,8 +85,8 @@ defmodule IbEx.Client.Messages.HistoricalTicks.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> %HistoricalTicks{
         message_id: #{msg.message_id}

--- a/lib/ib_ex/client/messages/ids/next_valid_id.ex
+++ b/lib/ib_ex/client/messages/ids/next_valid_id.ex
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.Ids.NextValidId do
   Gets the next valid id to be used for order placement
   """
   require Logger
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct version: nil, next_valid_id: nil
 
@@ -20,8 +21,8 @@ defmodule IbEx.Client.Messages.Ids.NextValidId do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %NextValidId{version: #{msg.version}, next_valid_id: #{msg.next_valid_id}}"
     end
   end

--- a/lib/ib_ex/client/messages/ids/request.ex
+++ b/lib/ib_ex/client/messages/ids/request.ex
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.Ids.Request do
   alias IbEx.Client.Protocols.Subscribable
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, version: @message_version, number_of_ids: 1
 
@@ -25,8 +26,8 @@ defmodule IbEx.Client.Messages.Ids.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> Ids.Request{number_of_ids: #{msg.number_of_ids}}"
     end
   end

--- a/lib/ib_ex/client/messages/init_connection/request.ex
+++ b/lib/ib_ex/client/messages/init_connection/request.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.InitConnection.Request do
   defstruct prefix: @prefix, version: nil
 
   alias IbEx.Client.Constants.ServerVersions
+  alias IbEx.Client.Protocols.Traceable
 
   def new do
     {:ok, %__MODULE__{version: ServerVersions.client_version()}}
@@ -21,8 +22,8 @@ defmodule IbEx.Client.Messages.InitConnection.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> API, #{msg.version}"
     end
   end

--- a/lib/ib_ex/client/messages/init_connection/response.ex
+++ b/lib/ib_ex/client/messages/init_connection/response.ex
@@ -6,6 +6,7 @@ defmodule IbEx.Client.Messages.InitConnection.Response do
   defstruct server_version: nil, connection_timestamp: nil
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields([server_version, timestamp_str]) do
     with {version, _} <- Integer.parse(server_version),
@@ -28,8 +29,8 @@ defmodule IbEx.Client.Messages.InitConnection.Response do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %InitConnection{version: #{msg.server_version} timestamp: #{msg.connection_timestamp}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_data/market_data_type.ex
+++ b/lib/ib_ex/client/messages/market_data/market_data_type.ex
@@ -4,6 +4,8 @@ defmodule IbEx.Client.Messages.MarketData.MarketDataType do
   and realtime.
   """
 
+  alias IbEx.Client.Protocols.Traceable
+
   defstruct request_id: nil, data_type: nil
 
   @type t :: %__MODULE__{
@@ -53,8 +55,8 @@ defmodule IbEx.Client.Messages.MarketData.MarketDataType do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %MarketData.MarketDataType{request_id: #{msg.request_id}, data_type: #{msg.data_type}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_data/option_chain.ex
+++ b/lib/ib_ex/client/messages/market_data/option_chain.ex
@@ -3,6 +3,8 @@ defmodule IbEx.Client.Messages.MarketData.OptionChain do
   Returned option chain struct 
   """
 
+  alias IbEx.Client.Protocols.Traceable
+
   defstruct request_id: nil,
             exchange: nil,
             underlying_conid: nil,
@@ -50,8 +52,8 @@ defmodule IbEx.Client.Messages.MarketData.OptionChain do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketData.OptionChain{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_data/option_chain_end.ex
+++ b/lib/ib_ex/client/messages/market_data/option_chain_end.ex
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.MarketData.OptionChainEnd do
   @moduledoc """
   End of option chain messages 
   """
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct request_id: nil
 
@@ -18,8 +19,8 @@ defmodule IbEx.Client.Messages.MarketData.OptionChainEnd do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketData.OptionChainEnd{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_data/request_cancel_data.ex
+++ b/lib/ib_ex/client/messages/market_data/request_cancel_data.ex
@@ -18,6 +18,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestCancelData do
 
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @spec new() :: {:ok, t()} | {:error, :not_implemented}
   def new() do
@@ -35,8 +36,8 @@ defmodule IbEx.Client.Messages.MarketData.RequestCancelData do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> %MarketData.RequestCancelData{request_id: #{msg.request_id}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_data/request_data.ex
+++ b/lib/ib_ex/client/messages/market_data/request_data.ex
@@ -29,6 +29,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestData do
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @type t :: %__MODULE__{
           message_id: non_neg_integer(),
@@ -82,10 +83,10 @@ defmodule IbEx.Client.Messages.MarketData.RequestData do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Traceable, for: __MODULE__ do
     alias IbEx.Client.Types.Contract
 
-    def inspect(msg, _opts) do
+    def to_s(msg) do
       contract = Enum.join(Contract.serialize(msg.contract, false), ", ")
 
       """

--- a/lib/ib_ex/client/messages/market_data/request_historical_data.ex
+++ b/lib/ib_ex/client/messages/market_data/request_historical_data.ex
@@ -36,6 +36,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalData do
   alias IbEx.Client.Constants.{WhatToShow, BarSizes, Durations}
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Protocols.Traceable
 
   @type end_date_time_type :: DateTime.t() | nil
   @type t :: %__MODULE__{
@@ -141,10 +142,10 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalData do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Traceable, for: __MODULE__ do
     alias IbEx.Client.Types.Contract
 
-    def inspect(msg, _opts) do
+    def to_s(msg) do
       contract = Enum.join(Contract.serialize(msg.contract, false), ", ")
 
       """

--- a/lib/ib_ex/client/messages/market_data/request_market_data_type.ex
+++ b/lib/ib_ex/client/messages/market_data/request_market_data_type.ex
@@ -22,6 +22,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataType do
 
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Messages.MarketData.MarketDataType
+  alias IbEx.Client.Protocols.Traceable
 
   @type t :: %__MODULE__{
           message_id: non_neg_integer(),
@@ -62,10 +63,10 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataType do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Traceable, for: __MODULE__ do
     alias IbEx.Client.Messages.MarketData.MarketDataType
 
-    def inspect(msg, _opts) do
+    def to_s(msg) do
       """
       --> MarketData.RequestMarketDataType{
         market_data_type: :#{MarketDataType.integer_to_atom(msg.market_data_type)}

--- a/lib/ib_ex/client/messages/market_data/request_option_chain.ex
+++ b/lib/ib_ex/client/messages/market_data/request_option_chain.ex
@@ -12,6 +12,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestOptionChain do
 
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @type t :: %__MODULE__{
           message_id: non_neg_integer(),
@@ -55,8 +56,8 @@ defmodule IbEx.Client.Messages.MarketData.RequestOptionChain do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> MarketData.RequestOptionChain{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_data/tick_generic.ex
+++ b/lib/ib_ex/client/messages/market_data/tick_generic.ex
@@ -18,6 +18,7 @@ defmodule IbEx.Client.Messages.MarketData.TickGeneric do
 
   alias IbEx.Client.Constants.TickTypes
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   @spec from_fields(list(String.t())) :: {:ok, t()} | {:error, :invalid_args}
   def from_fields([_, request_id, tick_type_str, value]) do
@@ -43,8 +44,8 @@ defmodule IbEx.Client.Messages.MarketData.TickGeneric do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %MarketData.TickGeneric{request_id: #{msg.request_id}, tick_type: #{msg.tick_type}, value: #{msg.value}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_data/tick_news.ex
+++ b/lib/ib_ex/client/messages/market_data/tick_news.ex
@@ -6,6 +6,7 @@ defmodule IbEx.Client.Messages.MarketData.TickNews do
   defstruct request_id: nil, headline: nil
 
   alias IbEx.Client.Types.NewsHeadline
+  alias IbEx.Client.Protocols.Traceable
 
   @type t :: %__MODULE__{
           request_id: String.t(),
@@ -27,8 +28,8 @@ defmodule IbEx.Client.Messages.MarketData.TickNews do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketData.TickNews{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_data/tick_price.ex
+++ b/lib/ib_ex/client/messages/market_data/tick_price.ex
@@ -32,6 +32,7 @@ defmodule IbEx.Client.Messages.MarketData.TickPrice do
 
   alias IbEx.Client.Utils
   alias IbEx.Client.Constants.TickTypes
+  alias IbEx.Client.Protocols.Traceable
 
   @autoexecute_flag 1
   @past_limit_flag 2
@@ -66,8 +67,8 @@ defmodule IbEx.Client.Messages.MarketData.TickPrice do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketData.TickPrice{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_data/tick_request_params.ex
+++ b/lib/ib_ex/client/messages/market_data/tick_request_params.ex
@@ -19,6 +19,7 @@ defmodule IbEx.Client.Messages.MarketData.TickRequestParams do
         }
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   @spec from_fields(list(String.t())) :: {:ok, t()} | {:error, :invalid_args}
   def from_fields([request_id, min_tick_str, bbo_exchange_str, snapshot_perms_str]) do
@@ -36,8 +37,8 @@ defmodule IbEx.Client.Messages.MarketData.TickRequestParams do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %MarketData.TickRequestParams{request_id: #{msg.request_id}, min_tick: #{msg.min_tick}, bbo_exchange: #{msg.bbo_exchange}, snapshot_permissions: #{msg.snapshot_permissions}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_data/tick_size.ex
+++ b/lib/ib_ex/client/messages/market_data/tick_size.ex
@@ -18,6 +18,7 @@ defmodule IbEx.Client.Messages.MarketData.TickSize do
 
   alias IbEx.Client.Utils
   alias IbEx.Client.Constants.TickTypes
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields([_, request_id, tick_type_str, size]) do
     tick_type = decode_tick_type(tick_type_str)
@@ -42,8 +43,8 @@ defmodule IbEx.Client.Messages.MarketData.TickSize do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %MarketData.TickSize{request_id: #{msg.request_id}, tick_type: #{msg.tick_type}, size: #{msg.size}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_data/tick_string.ex
+++ b/lib/ib_ex/client/messages/market_data/tick_string.ex
@@ -16,6 +16,7 @@ defmodule IbEx.Client.Messages.MarketData.TickString do
           value: String.t()
         }
   alias IbEx.Client.Constants.TickTypes
+  alias IbEx.Client.Protocols.Traceable
 
   @spec from_fields(list(String.t())) :: {:ok, t()} | {:error, :invalid_args}
   def from_fields([_, request_id, tick_type_str, value]) do
@@ -41,8 +42,8 @@ defmodule IbEx.Client.Messages.MarketData.TickString do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %MarketData.TickString{request_id: #{msg.request_id}, tick_type: #{msg.tick_type}, value: #{msg.value}}"
     end
   end

--- a/lib/ib_ex/client/messages/market_depth/cancel_data.ex
+++ b/lib/ib_ex/client/messages/market_depth/cancel_data.ex
@@ -23,6 +23,7 @@ defmodule IbEx.Client.Messages.MarketDepth.CancelData do
 
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @spec new(boolean()) :: {:ok, t()} | {:error, :not_implemented}
   def new(is_smart_depth \\ true) do
@@ -56,8 +57,8 @@ defmodule IbEx.Client.Messages.MarketDepth.CancelData do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> %MarketDepth.CancelData{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_depth/exchanges.ex
+++ b/lib/ib_ex/client/messages/market_depth/exchanges.ex
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.MarketDepth.Exchanges do
 
   alias IbEx.Client.Protocols.Subscribable
   alias IbEx.Client.Types.MarketDepthDescription
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct items: nil
 
@@ -34,8 +35,8 @@ defmodule IbEx.Client.Messages.MarketDepth.Exchanges do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketDepth.Exchanges{items: #{inspect(msg.items)}}
       """

--- a/lib/ib_ex/client/messages/market_depth/l2_data_multiple.ex
+++ b/lib/ib_ex/client/messages/market_depth/l2_data_multiple.ex
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataMultiple do
 
   alias IbEx.Client.Utils
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct request_id: nil,
             position: nil,
@@ -54,8 +55,8 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataMultiple do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketDepth.L2DataMultiple{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_depth/l2_data_single.ex
+++ b/lib/ib_ex/client/messages/market_depth/l2_data_single.ex
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataSingle do
 
   alias IbEx.Client.Utils
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct request_id: nil,
             position: nil,
@@ -48,8 +49,8 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataSingle do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %MarketDepth.L2DataSingle{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_depth/request_data.ex
+++ b/lib/ib_ex/client/messages/market_depth/request_data.ex
@@ -13,6 +13,7 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestData do
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   @version 5
 
@@ -69,8 +70,8 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestData do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> MarketDepth.RequestData{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/market_depth/request_exchanges.ex
+++ b/lib/ib_ex/client/messages/market_depth/request_exchanges.ex
@@ -5,6 +5,7 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestExchanges do
 
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil
 
@@ -26,8 +27,8 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestExchanges do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(_msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(_msg) do
       "--> RequestExchanges{}"
     end
   end

--- a/lib/ib_ex/client/messages/matching_symbols/request.ex
+++ b/lib/ib_ex/client/messages/matching_symbols/request.ex
@@ -6,6 +6,7 @@ defmodule IbEx.Client.Messages.MatchingSymbols.Request do
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct pattern: nil, request_id: nil, message_id: nil
 
@@ -27,8 +28,8 @@ defmodule IbEx.Client.Messages.MatchingSymbols.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> MatchingSymbols{id: #{msg.message_id}, request_id: #{msg.request_id}, pattern: #{msg.pattern}}"
     end
   end

--- a/lib/ib_ex/client/messages/misc/managed_accounts.ex
+++ b/lib/ib_ex/client/messages/misc/managed_accounts.ex
@@ -1,6 +1,8 @@
 defmodule IbEx.Client.Messages.Misc.ManagedAccounts do
   require Logger
 
+  alias IbEx.Client.Protocols.Traceable
+
   defstruct version: nil, accounts: nil
 
   def from_fields([version, accounts]) do
@@ -17,8 +19,8 @@ defmodule IbEx.Client.Messages.Misc.ManagedAccounts do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %ManagedAccounts{version: #{msg.version} accounts: #{msg.accounts}}"
     end
   end

--- a/lib/ib_ex/client/messages/news/article_data.ex
+++ b/lib/ib_ex/client/messages/news/article_data.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.News.ArticleData do
   defstruct request_id: nil, article: nil
 
   alias IbEx.Client.Types.NewsArticle
+  alias IbEx.Client.Protocols.Traceable
 
   @type t :: %__MODULE__{
           request_id: String.t(),
@@ -29,8 +30,8 @@ defmodule IbEx.Client.Messages.News.ArticleData do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %News.ArticleData{item: #{inspect(msg.item)}}
       """

--- a/lib/ib_ex/client/messages/news/bulletins.ex
+++ b/lib/ib_ex/client/messages/news/bulletins.ex
@@ -16,6 +16,8 @@ defmodule IbEx.Client.Messages.News.Bulletins do
 
   defstruct type: nil, message: nil, exchange: nil
 
+  alias IbEx.Client.Protocols.Traceable
+
   def from_fields([type, message, exchange]) do
     {
       :ok,
@@ -40,8 +42,8 @@ defmodule IbEx.Client.Messages.News.Bulletins do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %News.Bulletins{
         type: #{msg.type},

--- a/lib/ib_ex/client/messages/news/cancel_bulletins.ex
+++ b/lib/ib_ex/client/messages/news/cancel_bulletins.ex
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.News.CancelBulletins do
 
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, version: @message_version
 
@@ -31,8 +32,8 @@ defmodule IbEx.Client.Messages.News.CancelBulletins do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(_msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(_msg) do
       "--> News.CancelBulletins{}"
     end
   end

--- a/lib/ib_ex/client/messages/news/historical_news.ex
+++ b/lib/ib_ex/client/messages/news/historical_news.ex
@@ -3,6 +3,8 @@ defmodule IbEx.Client.Messages.News.HistoricalNews do
   Received message with the details of a historical news article
   """
 
+  alias IbEx.Client.Protocols.Traceable
+
   defstruct request_id: nil, timestamp: nil, provider_code: nil, article_id: nil, headline: nil
 
   # TODO: Refactor this message to use the NewsHeadline type
@@ -24,8 +26,8 @@ defmodule IbEx.Client.Messages.News.HistoricalNews do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %News.HistoricalNews{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/news/historical_news_end.ex
+++ b/lib/ib_ex/client/messages/news/historical_news_end.ex
@@ -12,6 +12,7 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsEnd do
         }
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   @spec from_fields(list(binary())) :: {:ok, t()} | {:error, :invalid_args}
   def from_fields([request_id, has_more]) do
@@ -22,8 +23,8 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsEnd do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- %News.HistoricalNewsEnd{request_id: #{msg.request_id}, has_more: #{msg.has_more}}"
     end
   end

--- a/lib/ib_ex/client/messages/news/providers.ex
+++ b/lib/ib_ex/client/messages/news/providers.ex
@@ -5,6 +5,8 @@ defmodule IbEx.Client.Messages.News.Providers do
   Receives a list of different news providers 
   """
 
+  alias IbEx.Client.Protocols.Traceable
+
   defstruct items: nil
 
   def from_fields([_number_of_items | rest]) when length(rest) >= 5 do
@@ -24,8 +26,8 @@ defmodule IbEx.Client.Messages.News.Providers do
     build_items(rest, [{code, name} | acc])
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %News.Providers{items: #{inspect(msg.items)}}
       """

--- a/lib/ib_ex/client/messages/news/request_article.ex
+++ b/lib/ib_ex/client/messages/news/request_article.ex
@@ -14,6 +14,7 @@ defmodule IbEx.Client.Messages.News.RequestArticle do
         }
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   @spec new(non_neg_integer(), String.t(), String.t()) :: {:ok, t()}
   def new(request_id, provider_code, provider_id) do
@@ -44,8 +45,8 @@ defmodule IbEx.Client.Messages.News.RequestArticle do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- %News.RequestArticle{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/news/request_bulletins.ex
+++ b/lib/ib_ex/client/messages/news/request_bulletins.ex
@@ -14,6 +14,7 @@ defmodule IbEx.Client.Messages.News.RequestBulletins do
 
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, version: @message_version, all_messages: nil
 
@@ -42,8 +43,8 @@ defmodule IbEx.Client.Messages.News.RequestBulletins do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> News.RequestBulletins{all_messages: #{msg.all_messages}}"
     end
   end

--- a/lib/ib_ex/client/messages/news/request_historical_news.ex
+++ b/lib/ib_ex/client/messages/news/request_historical_news.ex
@@ -35,6 +35,7 @@ defmodule IbEx.Client.Messages.News.RequestHistoricalNews do
   @type t :: %__MODULE__{message_id: non_neg_integer()}
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   @spec new(non_neg_integer(), non_neg_integer(), binary(), DateTime.t(), DateTime.t(), non_neg_integer()) ::
           {:ok, t()} | {:error, :not_implemented}
@@ -86,8 +87,8 @@ defmodule IbEx.Client.Messages.News.RequestHistoricalNews do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> News.RequestHistoricalNews{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/news/request_providers.ex
+++ b/lib/ib_ex/client/messages/news/request_providers.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.News.RequestProviders do
   @type t :: %__MODULE__{message_id: non_neg_integer()}
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   @spec new() :: {:ok, t()} | {:error, :not_implemented}
   def new do
@@ -25,8 +26,8 @@ defmodule IbEx.Client.Messages.News.RequestProviders do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(_msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(_msg) do
       "--> News.RequestProviders{}"
     end
   end

--- a/lib/ib_ex/client/messages/orders/request_cancel_order.ex
+++ b/lib/ib_ex/client/messages/orders/request_cancel_order.ex
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.Orders.RequestCancelOrder do
   * %OrderCancel{}
   """
   alias IbEx.Client.Types.OrderCancel
+  alias IbEx.Client.Protocols.Traceable
 
   @version 1
 
@@ -60,8 +61,8 @@ defmodule IbEx.Client.Messages.Orders.RequestCancelOrder do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> %MarketData.RequestCancelOrder{order_id: #{msg.order_id}}"
     end
   end

--- a/lib/ib_ex/client/messages/orders/request_create_order.ex
+++ b/lib/ib_ex/client/messages/orders/request_create_order.ex
@@ -16,6 +16,7 @@ defmodule IbEx.Client.Messages.Orders.RequestCreateOrder do
 
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.{Order, Contract}
+  alias IbEx.Client.Protocols.Traceable
 
   @type t :: %__MODULE__{
           message_id: non_neg_integer(),
@@ -76,8 +77,8 @@ defmodule IbEx.Client.Messages.Orders.RequestCreateOrder do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       contract_str = Enum.join(Contract.serialize(msg.contract, false), ", ")
 
       """

--- a/lib/ib_ex/client/messages/pnl/all_positions_cancel.ex
+++ b/lib/ib_ex/client/messages/pnl/all_positions_cancel.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsCancel do
   """
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, request_id: nil
 
@@ -29,8 +30,8 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsCancel do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> Pnl.AllPositionsCancel{message_id: #{msg.message_id}, request_id: #{msg.request_id}}
       """

--- a/lib/ib_ex/client/messages/pnl/all_positions_request.ex
+++ b/lib/ib_ex/client/messages/pnl/all_positions_request.ex
@@ -10,6 +10,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsRequest do
   """
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, request_id: nil, account: nil, model_code: ""
 
@@ -47,8 +48,8 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsRequest do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> Pnl.AllPositionsRequest{
         message_id: #{msg.message_id},

--- a/lib/ib_ex/client/messages/pnl/all_positions_update.ex
+++ b/lib/ib_ex/client/messages/pnl/all_positions_update.ex
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsUpdate do
   """
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct request_id: nil, daily_pnl: nil, unrealized_pnl: nil, realized_pnl: nil
 
@@ -26,8 +27,8 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsUpdate do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- Pnl.AllPositionsUpdate{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/pnl/single_position_cancel.ex
+++ b/lib/ib_ex/client/messages/pnl/single_position_cancel.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionCancel do
   """
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, request_id: nil
 
@@ -29,8 +30,8 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionCancel do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> Pnl.SinglePositionCancel{message_id: #{msg.message_id}, request_id: #{msg.request_id}}
       """

--- a/lib/ib_ex/client/messages/pnl/single_position_request.ex
+++ b/lib/ib_ex/client/messages/pnl/single_position_request.ex
@@ -12,6 +12,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionRequest do
 
   alias IbEx.Client.Messages.Pnl.AllPositionsRequest
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, request_id: nil, account: nil, model_code: "", conid: nil
 
@@ -43,8 +44,8 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionRequest do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       --> Pnl.SinglePositionRequest{
         message_id: #{msg.message_id},

--- a/lib/ib_ex/client/messages/pnl/single_position_update.ex
+++ b/lib/ib_ex/client/messages/pnl/single_position_update.ex
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdate do
   """
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct request_id: nil, position: nil, daily_pnl: nil, unrealized_pnl: nil, realized_pnl: nil, value: nil
 
@@ -28,8 +29,8 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdate do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       """
       <-- Pnl.SinglePositionUpdate{
         request_id: #{msg.request_id},

--- a/lib/ib_ex/client/messages/start_api/request.ex
+++ b/lib/ib_ex/client/messages/start_api/request.ex
@@ -8,6 +8,7 @@ defmodule IbEx.Client.Messages.StartApi.Request do
   @version 2
 
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, optional_capabilities: nil, client_id: nil, version: @version
 
@@ -46,8 +47,8 @@ defmodule IbEx.Client.Messages.StartApi.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> StartAPI{id: #{msg.message_id}, version: #{msg.version}, client_id: #{msg.client_id}, opt_capabilities: #{inspect(msg.optional_capabilities)}}"
     end
   end

--- a/lib/ib_ex/client/messages/tick_by_tick_data/cancel_tick_by_tick_data.ex
+++ b/lib/ib_ex/client/messages/tick_by_tick_data/cancel_tick_by_tick_data.ex
@@ -5,6 +5,7 @@ defmodule IbEx.Client.Messages.TickByTickData.CancelTickByTickData do
 
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, request_id: nil
 
@@ -34,8 +35,8 @@ defmodule IbEx.Client.Messages.TickByTickData.CancelTickByTickData do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "--> CancelTickByTickData{message_id: #{msg.message_id}, request_id: #{msg.request_id}}"
     end
   end

--- a/lib/ib_ex/client/messages/tick_by_tick_data/request.ex
+++ b/lib/ib_ex/client/messages/tick_by_tick_data/request.ex
@@ -17,6 +17,7 @@ defmodule IbEx.Client.Messages.TickByTickData.Request do
   alias IbEx.Client.Messages.Base
   alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Protocols.Traceable
 
   defstruct message_id: nil, request_id: nil, contract: nil, tick_type: nil, number_of_ticks: nil, ignore_size: nil
 
@@ -84,8 +85,8 @@ defmodule IbEx.Client.Messages.TickByTickData.Request do
     end
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "-->
         TickByTickData{
           message_id: #{msg.message_id},

--- a/lib/ib_ex/client/messages/tick_by_tick_data/tick_by_tick.ex
+++ b/lib/ib_ex/client/messages/tick_by_tick_data/tick_by_tick.ex
@@ -14,8 +14,7 @@ defmodule IbEx.Client.Messages.TickByTickData.TickByTick do
   alias IbEx.Client.Types.Trade
   alias IbEx.Client.Types.BidAsk
   alias IbEx.Client.Types.MidPoint
-
-  require Logger
+  alias IbEx.Client.Protocols.Traceable
 
   def from_fields([request_id, tick_type | rest]) do
     case parse_data_fields(tick_type, rest) do
@@ -46,8 +45,8 @@ defmodule IbEx.Client.Messages.TickByTickData.TickByTick do
     MidPoint.from_tick_by_tick(fields)
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(msg, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(msg) do
       "<-- TickByTick{request_id: #{msg.request_id}, tick: #{inspect(msg.tick)}}"
     end
   end

--- a/lib/ib_ex/client/protocols/traceable.ex
+++ b/lib/ib_ex/client/protocols/traceable.ex
@@ -1,0 +1,8 @@
+defprotocol IbEx.Client.Protocols.Traceable do
+  @fallback_to_any true
+
+  @doc """
+  Turns the message into a string that can be used when tracing message flows
+  """
+  def to_s(msg)
+end

--- a/lib/ib_ex/client/types/bid_ask.ex
+++ b/lib/ib_ex/client/types/bid_ask.ex
@@ -13,6 +13,7 @@ defmodule IbEx.Client.Types.BidAsk do
             ask_past_high: nil
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   def from_tick_by_tick([ts, bid_price_str, ask_price_str, bid_size_str, ask_size_str, mask_str]) do
     case DateTime.from_unix(String.to_integer(ts)) do
@@ -43,8 +44,8 @@ defmodule IbEx.Client.Types.BidAsk do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(tick, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(tick) do
       "BidAsk{
         timestamp: #{tick.timestamp},
         bid_price: #{tick.bid_price},

--- a/lib/ib_ex/client/types/market_depth_description.ex
+++ b/lib/ib_ex/client/types/market_depth_description.ex
@@ -3,6 +3,8 @@ defmodule IbEx.Client.Types.MarketDepthDescription do
     Represents a description of an exchange offering market depth data 
   """
 
+  alias IbEx.Client.Protocols.Traceable
+
   defstruct exchange: nil, security_type: nil, listing_exchange: nil, service_data_type: nil, aggregate_group: nil
 
   def from_market_depth_exchanges([exchange, sec_type, listing_exchange, sd_type, agg_group]) do
@@ -22,8 +24,8 @@ defmodule IbEx.Client.Types.MarketDepthDescription do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(desc, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(desc) do
       "%MarketDepthDescription{exchange: #{desc.exchange}, security_type: #{desc.security_type}}"
     end
   end

--- a/lib/ib_ex/client/types/mid_point.ex
+++ b/lib/ib_ex/client/types/mid_point.ex
@@ -3,8 +3,9 @@ defmodule IbEx.Client.Types.MidPoint do
     Represents a MidPoint price from the Time & Sales feed
   """
 
-  defstruct timestamp: nil,
-            mid_point: nil
+  alias IbEx.Client.Protocols.Traceable
+
+  defstruct timestamp: nil, mid_point: nil
 
   def from_tick_by_tick([ts, mid_point]) do
     case DateTime.from_unix(String.to_integer(ts)) do
@@ -23,8 +24,8 @@ defmodule IbEx.Client.Types.MidPoint do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(trade, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(trade) do
       "%MidPoint{timestamp: #{trade.timestamp}, mid_point: #{trade.mid_point}}"
     end
   end

--- a/lib/ib_ex/client/types/trade.ex
+++ b/lib/ib_ex/client/types/trade.ex
@@ -13,6 +13,7 @@ defmodule IbEx.Client.Types.Trade do
             unreported: nil
 
   alias IbEx.Client.Utils
+  alias IbEx.Client.Protocols.Traceable
 
   def from_tick_by_tick([ts, price_str, size_str, mask_str, exchange, conditions]) do
     from_historical_ticks_last([ts, mask_str, size_str, price_str, exchange, conditions])
@@ -51,8 +52,8 @@ defmodule IbEx.Client.Types.Trade do
     {:error, :invalid_args}
   end
 
-  defimpl Inspect, for: __MODULE__ do
-    def inspect(trade, _opts) do
+  defimpl Traceable, for: __MODULE__ do
+    def to_s(trade) do
       "%Trade{timestamp: #{trade.timestamp}, price: #{trade.price}, size: #{trade.size}, exchange: #{trade.exchange}, conditions: #{trade.conditions}}"
     end
   end

--- a/test/ib_ex/client/messages/account_data/account_detail_test.exs
+++ b/test/ib_ex/client/messages/account_data/account_detail_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetailTest do
   alias IbEx.Client.Messages.AccountData.AccountDetail
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   @valid_fields ["1", "NetLiquidation", "100000", "USD", "MYACCT123"]
@@ -29,11 +30,11 @@ defmodule IbEx.Client.Messages.AccountData.AccountDetailTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = AccountDetail.from_fields(@valid_fields)
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                "<-- AccountDetail{field: NetLiquidation, value: 100000, currency: USD, account: MYACCT123}"
     end
   end

--- a/test/ib_ex/client/messages/account_data/account_download_end_test.exs
+++ b/test/ib_ex/client/messages/account_data/account_download_end_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEndTest do
 
   alias IbEx.Client.Messages.AccountData.AccountDownloadEnd
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -21,10 +22,10 @@ defmodule IbEx.Client.Messages.AccountData.AccountDownloadEndTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = AccountDownloadEnd.from_fields(["3", "ACCT456"])
-      assert inspect(msg) == "<-- AccountDownloadEnd{account: ACCT456}"
+      assert Traceable.to_s(msg) == "<-- AccountDownloadEnd{account: ACCT456}"
     end
   end
 

--- a/test/ib_ex/client/messages/account_data/account_update_time_test.exs
+++ b/test/ib_ex/client/messages/account_data/account_update_time_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTimeTest do
 
   alias IbEx.Client.Messages.AccountData.AccountUpdateTime
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -26,13 +27,13 @@ defmodule IbEx.Client.Messages.AccountData.AccountUpdateTimeTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the struct" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
       {:ok, msg} = AccountUpdateTime.from_fields(["1", "10:47"])
       {:ok, ts} = NaiveDateTime.new(Date.utc_today(), ~T[10:47:00])
 
       expected_output = "<-- AccountUpdateTime{timestamp: #{ts}}"
-      assert inspect(msg) == expected_output
+      assert Traceable.to_s(msg) == expected_output
     end
   end
 

--- a/test/ib_ex/client/messages/account_data/request_test.exs
+++ b/test/ib_ex/client/messages/account_data/request_test.exs
@@ -7,6 +7,7 @@ defmodule IbEx.Client.Messages.AccountData.RequestTest do
   alias IbEx.Client.Messages.AccountData.AccountUpdateTime
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/2" do
@@ -26,12 +27,12 @@ defmodule IbEx.Client.Messages.AccountData.RequestTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = Request.new(true)
 
       # Adjust this expected string to the format that your Inspect implementation produces.
-      assert inspect(msg) == "--> AccountUpdates{message_id: 6, subscribe: true, account_code: nil}"
+      assert Traceable.to_s(msg) == "--> AccountUpdates{message_id: 6, subscribe: true, account_code: nil}"
     end
   end
 

--- a/test/ib_ex/client/messages/current_time/request_test.exs
+++ b/test/ib_ex/client/messages/current_time/request_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.CurrentTime.RequestTest do
   alias IbEx.Client.Messages.CurrentTime.Request
   alias IbEx.Client.Messages.CurrentTime.Response
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/1" do
@@ -22,11 +23,11 @@ defmodule IbEx.Client.Messages.CurrentTime.RequestTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = Request.new()
 
-      assert inspect(msg) == "--> %CurrentTime{id: 49, version: 1}"
+      assert Traceable.to_s(msg) == "--> %CurrentTime{id: 49, version: 1}"
     end
   end
 

--- a/test/ib_ex/client/messages/executions/execution_data_end_test.exs
+++ b/test/ib_ex/client/messages/executions/execution_data_end_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataEndTest do
 
   alias IbEx.Client.Messages.Executions.ExecutionDataEnd
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -22,11 +23,11 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataEndTest do
     end
   end
 
-  describe "inspect/2" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %ExecutionDataEnd{version: 3, request_id: "123"}
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- ExecutionDataEnd{version: 3, request_id: 123}
                """

--- a/test/ib_ex/client/messages/executions/execution_data_test.exs
+++ b/test/ib_ex/client/messages/executions/execution_data_test.exs
@@ -6,6 +6,7 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataTest do
   alias IbEx.Client.Types.Execution
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   @fields [
@@ -100,11 +101,11 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataTest do
     end
   end
 
-  describe "inspect/2" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = ExecutionData.from_fields(@fields)
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- ExecutionData{
                  request_id: 1,

--- a/test/ib_ex/client/messages/executions/request_test.exs
+++ b/test/ib_ex/client/messages/executions/request_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.Executions.RequestTest do
   alias IbEx.Client.Messages.Executions.Request
   alias IbEx.Client.Types.ExecutionsFilter
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/2" do
@@ -28,15 +29,15 @@ defmodule IbEx.Client.Messages.Executions.RequestTest do
     end
   end
 
-  describe "inspect/2" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %Request{
         message_id: 7,
         request_id: 90001,
         filter: %ExecutionsFilter{client_id: 123}
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> Executions.Request{
                  message_id: 7,

--- a/test/ib_ex/client/messages/ids/next_valid_id_test.exs
+++ b/test/ib_ex/client/messages/ids/next_valid_id_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Ids.NextValidIdTest do
   use ExUnit.Case
 
   alias IbEx.Client.Messages.Ids.NextValidId
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "parses valid version and id strings into a NextValidId struct" do
@@ -19,10 +20,10 @@ defmodule IbEx.Client.Messages.Ids.NextValidIdTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/2 returns a human-readable version of the message" do
       next_valid_id = NextValidId.from_fields(["1", "16"]) |> elem(1)
-      assert inspect(next_valid_id) == "<-- %NextValidId{version: 1, next_valid_id: 16}"
+      assert Traceable.to_s(next_valid_id) == "<-- %NextValidId{version: 1, next_valid_id: 16}"
     end
   end
 end

--- a/test/ib_ex/client/messages/ids/request_test.exs
+++ b/test/ib_ex/client/messages/ids/request_test.exs
@@ -1,6 +1,8 @@
 defmodule IbEx.Client.Messages.Ids.RequestTest do
   use ExUnit.Case, async: true
+
   alias IbEx.Client.Messages.Ids.Request
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/1" do
     test "creates a new Request with a valid message id" do
@@ -21,10 +23,10 @@ defmodule IbEx.Client.Messages.Ids.RequestTest do
     end
   end
 
-  describe "inspect/2" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, request} = Request.new()
-      assert inspect(request) == "--> Ids.Request{number_of_ids: 1}"
+      assert Traceable.to_s(request) == "--> Ids.Request{number_of_ids: 1}"
     end
   end
 end

--- a/test/ib_ex/client/messages/market_data/market_data_type_test.exs
+++ b/test/ib_ex/client/messages/market_data/market_data_type_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.MarketDataTypeTest do
 
   alias IbEx.Client.Messages.MarketData.MarketDataType
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -55,10 +56,10 @@ defmodule IbEx.Client.Messages.MarketData.MarketDataTypeTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects MarketDataType struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %MarketDataType{request_id: 9001, data_type: :live}
-      assert inspect(msg) == "<-- %MarketData.MarketDataType{request_id: 9001, data_type: live}"
+      assert Traceable.to_s(msg) == "<-- %MarketData.MarketDataType{request_id: 9001, data_type: live}"
     end
   end
 

--- a/test/ib_ex/client/messages/market_data/option_chain_end_test.exs
+++ b/test/ib_ex/client/messages/market_data/option_chain_end_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.MarketData.OptionChainEndTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MarketData.OptionChainEnd
+  alias IbEx.Client.Protocols.Traceable
 
   @request_id 9001
 
@@ -21,9 +22,9 @@ defmodule IbEx.Client.Messages.MarketData.OptionChainEndTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects OptionChainEnd struct correctly" do
-      assert inspect(@msg) ==
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
+      assert Traceable.to_s(@msg) ==
                """
                <-- %MarketData.OptionChainEnd{
                  request_id: #{@request_id},

--- a/test/ib_ex/client/messages/market_data/option_chain_test.exs
+++ b/test/ib_ex/client/messages/market_data/option_chain_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.MarketData.OptionChainTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MarketData.OptionChain
+  alias IbEx.Client.Protocols.Traceable
 
   @attrs %{
     request_id: "9001",
@@ -62,9 +63,9 @@ defmodule IbEx.Client.Messages.MarketData.OptionChainTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects OptionChain struct correctly" do
-      assert inspect(@msg) ==
+  describe "Traceab;e" do
+    test "to_s/1 returns a human-readable version of the message" do
+      assert Traceable.to_s(@msg) ==
                """
                <-- %MarketData.OptionChain{
                  request_id: 9001,

--- a/test/ib_ex/client/messages/market_data/request_cancel_data_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_cancel_data_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestCancelDataTest do
 
   alias IbEx.Client.Messages.MarketData.RequestCancelData
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/1" do
@@ -21,10 +22,10 @@ defmodule IbEx.Client.Messages.MarketData.RequestCancelDataTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects RequestCancelData struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %RequestCancelData{request_id: 1000}
-      assert inspect(msg) == "--> %MarketData.RequestCancelData{request_id: 1000}"
+      assert Traceable.to_s(msg) == "--> %MarketData.RequestCancelData{request_id: 1000}"
     end
   end
 

--- a/test/ib_ex/client/messages/market_data/request_data_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_data_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestDataTest do
   alias IbEx.Client.Messages.MarketData.RequestData
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   @contract %Contract{
@@ -59,8 +60,8 @@ defmodule IbEx.Client.Messages.MarketData.RequestDataTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the struct" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
       msg = %RequestData{
         request_id: 123,
         contract: @contract,
@@ -71,7 +72,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestDataTest do
 
       contract_str = Enum.join(Contract.serialize(@contract, false), ", ")
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> MarketData.RequestData{
                  request_id: 123,

--- a/test/ib_ex/client/messages/market_data/request_historical_data_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_historical_data_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MarketData.RequestHistoricalData
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Types.Contract
 
   @contract %Contract{
@@ -83,8 +84,8 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the struct" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
       msg = %RequestHistoricalData{
         request_id: 123,
         contract: @contract,
@@ -98,7 +99,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestHistoricalDataTest do
 
       contract_str = Enum.join(Contract.serialize(@contract, false), ", ")
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> MarketData.RequestHistoricalData{
                  request_id: 123,

--- a/test/ib_ex/client/messages/market_data/request_market_data_type_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_market_data_type_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataTypeTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Messages.MarketData.RequestMarketDataType
   alias IbEx.Client.Messages.MarketData.MarketDataType
   alias IbEx.Client.Subscriptions
@@ -26,14 +27,14 @@ defmodule IbEx.Client.Messages.MarketData.RequestMarketDataTypeTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the struct" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
       msg = %RequestMarketDataType{
         message_id: 59,
         market_data_type: 3
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> MarketData.RequestMarketDataType{
                  market_data_type: :#{MarketDataType.integer_to_atom(msg.market_data_type)}

--- a/test/ib_ex/client/messages/market_data/request_option_chain_test.exs
+++ b/test/ib_ex/client/messages/market_data/request_option_chain_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.MarketData.RequestOptionChainTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.MarketData.RequestOptionChain
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Types.Contract
 
   @contract %Contract{
@@ -63,9 +64,9 @@ defmodule IbEx.Client.Messages.MarketData.RequestOptionChainTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the struct" do
-      assert inspect(@msg) ==
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
+      assert Traceable.to_s(@msg) ==
                """
                --> MarketData.RequestOptionChain{
                  request_id: 123,

--- a/test/ib_ex/client/messages/market_data/tick_generic_test.exs
+++ b/test/ib_ex/client/messages/market_data/tick_generic_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.TickGenericTest do
 
   alias IbEx.Client.Messages.MarketData.TickGeneric
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -19,15 +20,15 @@ defmodule IbEx.Client.Messages.MarketData.TickGenericTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects TickSize struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %TickGeneric{
         request_id: "9001",
         tick_type: :halted,
         value: 0.0
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                "<-- %MarketData.TickGeneric{request_id: 9001, tick_type: halted, value: 0.0}"
     end
   end

--- a/test/ib_ex/client/messages/market_data/tick_news_test.exs
+++ b/test/ib_ex/client/messages/market_data/tick_news_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.MarketData.TickNewsTest do
   alias IbEx.Client.Messages.MarketData.TickNews
   alias IbEx.Client.Types.NewsHeadline
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   @valid_fields [
@@ -29,8 +30,8 @@ defmodule IbEx.Client.Messages.MarketData.TickNewsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects TickNews struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %TickNews{
         request_id: "1",
         headline: %NewsHeadline{
@@ -44,7 +45,7 @@ defmodule IbEx.Client.Messages.MarketData.TickNewsTest do
         }
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %MarketData.TickNews{
                  request_id: 1,

--- a/test/ib_ex/client/messages/market_data/tick_price_test.exs
+++ b/test/ib_ex/client/messages/market_data/tick_price_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.TickPriceTest do
 
   alias IbEx.Client.Messages.MarketData.TickPrice
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -24,8 +25,8 @@ defmodule IbEx.Client.Messages.MarketData.TickPriceTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects TickPrice struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %TickPrice{
         request_id: "123",
         tick_type: :bid,
@@ -37,7 +38,7 @@ defmodule IbEx.Client.Messages.MarketData.TickPriceTest do
         should_tick_for_size?: false
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %MarketData.TickPrice{
                  request_id: 123,

--- a/test/ib_ex/client/messages/market_data/tick_request_params_test.exs
+++ b/test/ib_ex/client/messages/market_data/tick_request_params_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.TickRequestParamsTest do
 
   alias IbEx.Client.Messages.MarketData.TickRequestParams
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -20,8 +21,8 @@ defmodule IbEx.Client.Messages.MarketData.TickRequestParamsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects TickRequestParams struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %TickRequestParams{
         request_id: "9001",
         min_tick: 0.01,
@@ -29,7 +30,7 @@ defmodule IbEx.Client.Messages.MarketData.TickRequestParamsTest do
         snapshot_permissions: 1
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                "<-- %MarketData.TickRequestParams{request_id: 9001, min_tick: 0.01, bbo_exchange: 9c0001, snapshot_permissions: 1}"
     end
   end

--- a/test/ib_ex/client/messages/market_data/tick_size_test.exs
+++ b/test/ib_ex/client/messages/market_data/tick_size_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.TickSizeTest do
 
   alias IbEx.Client.Messages.MarketData.TickSize
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -19,15 +20,15 @@ defmodule IbEx.Client.Messages.MarketData.TickSizeTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects TickSize struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %TickSize{
         request_id: "123",
         tick_type: :bid_size,
         size: Decimal.new("200")
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                "<-- %MarketData.TickSize{request_id: 123, tick_type: bid_size, size: 200}"
     end
   end

--- a/test/ib_ex/client/messages/market_data/tick_string_test.exs
+++ b/test/ib_ex/client/messages/market_data/tick_string_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketData.TickStringTest do
 
   alias IbEx.Client.Messages.MarketData.TickString
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -19,15 +20,15 @@ defmodule IbEx.Client.Messages.MarketData.TickStringTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects TickSize struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %TickString{
         request_id: "9001",
         tick_type: :last_timestamp,
         value: "1702662249"
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                "<-- %MarketData.TickString{request_id: 9001, tick_type: last_timestamp, value: 1702662249}"
     end
   end

--- a/test/ib_ex/client/messages/market_depth/cancel_data_test.exs
+++ b/test/ib_ex/client/messages/market_depth/cancel_data_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketDepth.CancelDataTest do
 
   alias IbEx.Client.Messages.MarketDepth.CancelData
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/0" do
@@ -21,9 +22,9 @@ defmodule IbEx.Client.Messages.MarketDepth.CancelDataTest do
     end
   end
 
-  describe "inspect/2 " do
-    test "returns a human-readable version of the message" do
-      assert inspect(%CancelData{request_id: 90001}) ==
+  describe "Traceable " do
+    test "to_s/1 returns a human-readable version of the message" do
+      assert Traceable.to_s(%CancelData{request_id: 90001}) ==
                """
                --> %MarketDepth.CancelData{
                  request_id: 90001,

--- a/test/ib_ex/client/messages/market_depth/exchanges_test.exs
+++ b/test/ib_ex/client/messages/market_depth/exchanges_test.exs
@@ -5,6 +5,7 @@ defmodule IbEx.Client.Messages.MarketDepth.ExchangesTest do
   alias IbEx.Client.Types.MarketDepthDescription
 
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   @fields [
@@ -42,16 +43,16 @@ defmodule IbEx.Client.Messages.MarketDepth.ExchangesTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 Exchanges struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       description = %MarketDepthDescription{
         exchange: "NYSE",
         security_type: "STK"
       }
 
-      assert inspect(%Exchanges{items: [description]}) ==
+      assert Traceable.to_s(%Exchanges{items: [description]}) ==
                """
-               <-- %MarketDepth.Exchanges{items: [%MarketDepthDescription{exchange: NYSE, security_type: STK}]}
+               <-- %MarketDepth.Exchanges{items: [%IbEx.Client.Types.MarketDepthDescription{exchange: \"NYSE\", security_type: \"STK\", listing_exchange: nil, service_data_type: nil, aggregate_group: nil}]}
                """
     end
   end

--- a/test/ib_ex/client/messages/market_depth/l2_data_multiple_test.exs
+++ b/test/ib_ex/client/messages/market_depth/l2_data_multiple_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataMultipleTest do
 
   alias IbEx.Client.Messages.MarketDepth.L2DataMultiple
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -101,8 +102,8 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataMultipleTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects L2DataMultiple struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       timestamp = DateTime.utc_now()
 
       msg = %L2DataMultiple{
@@ -117,7 +118,7 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataMultipleTest do
         timestamp: timestamp
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %MarketDepth.L2DataMultiple{
                  request_id: 90001,

--- a/test/ib_ex/client/messages/market_depth/l2_data_single_test.exs
+++ b/test/ib_ex/client/messages/market_depth/l2_data_single_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataSingleTest do
 
   alias IbEx.Client.Messages.MarketDepth.L2DataSingle
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "from_fields/1" do
@@ -89,8 +90,8 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataSingleTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects L2DataSingle struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       timestamp = DateTime.utc_now()
 
       msg = %L2DataSingle{
@@ -103,7 +104,7 @@ defmodule IbEx.Client.Messages.MarketDepth.L2DataSingleTest do
         timestamp: timestamp
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %MarketDepth.L2DataSingle{
                  request_id: 90001,

--- a/test/ib_ex/client/messages/market_depth/request_data_test.exs
+++ b/test/ib_ex/client/messages/market_depth/request_data_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestDataTest do
 
   alias IbEx.Client.Messages.MarketDepth.RequestData
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Subscriptions
 
@@ -39,8 +40,8 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestDataTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects RequestData struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       contract = %Contract{symbol: "AAPL", security_type: "STK"}
 
       msg = %RequestData{
@@ -50,7 +51,7 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestDataTest do
         smart_depth?: true
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> MarketDepth.RequestData{
                  request_id: 90001,

--- a/test/ib_ex/client/messages/market_depth/request_exchanges_test.exs
+++ b/test/ib_ex/client/messages/market_depth/request_exchanges_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestExchangesTest do
   alias IbEx.Client.Messages.MarketDepth.Exchanges
   alias IbEx.Client.Messages.MarketDepth.RequestExchanges
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/0" do
@@ -20,9 +21,9 @@ defmodule IbEx.Client.Messages.MarketDepth.RequestExchangesTest do
     end
   end
 
-  describe "inspect/2 " do
-    test "returns a human-readable version of the message" do
-      assert inspect(%RequestExchanges{}) == "--> RequestExchanges{}"
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
+      assert Traceable.to_s(%RequestExchanges{}) == "--> RequestExchanges{}"
     end
   end
 

--- a/test/ib_ex/client/messages/matching_symbols/request_test.exs
+++ b/test/ib_ex/client/messages/matching_symbols/request_test.exs
@@ -3,6 +3,7 @@ defmodule IbEx.Client.Messages.MatchingSymbols.RequestTest do
 
   alias IbEx.Client.Messages.MatchingSymbols.Request
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/1" do
@@ -23,12 +24,12 @@ defmodule IbEx.Client.Messages.MatchingSymbols.RequestTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = Request.new("AAPL")
       msg = %{msg | request_id: 1}
 
-      assert inspect(msg) == "--> MatchingSymbols{id: 81, request_id: 1, pattern: AAPL}"
+      assert Traceable.to_s(msg) == "--> MatchingSymbols{id: 81, request_id: 1, pattern: AAPL}"
     end
   end
 

--- a/test/ib_ex/client/messages/news/bulletins_test.exs
+++ b/test/ib_ex/client/messages/news/bulletins_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.BulletinsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.Bulletins
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "creates a regular_news message" do
@@ -35,15 +36,15 @@ defmodule IbEx.Client.Messages.News.BulletinsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %Bulletins{
         type: "regular_news",
         message: "Some news message",
         exchange: "NYSE"
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %News.Bulletins{
                  type: regular_news,

--- a/test/ib_ex/client/messages/news/cancel_bulletins_test.exs
+++ b/test/ib_ex/client/messages/news/cancel_bulletins_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.CancelBulletinsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.CancelBulletins
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/0" do
     test "creates the message successfully" do
@@ -19,9 +20,9 @@ defmodule IbEx.Client.Messages.News.CancelBulletinsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the struct" do
-      assert inspect(%CancelBulletins{}) == "--> News.CancelBulletins{}"
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
+      assert Traceable.to_s(%CancelBulletins{}) == "--> News.CancelBulletins{}"
     end
   end
 end

--- a/test/ib_ex/client/messages/news/historical_news_end_test.exs
+++ b/test/ib_ex/client/messages/news/historical_news_end_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsEndTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.HistoricalNewsEnd
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "creates the message" do
@@ -16,9 +17,9 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsEndTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the message" do
-      assert inspect(%HistoricalNewsEnd{request_id: "90001", has_more: true}) ==
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
+      assert Traceable.to_s(%HistoricalNewsEnd{request_id: "90001", has_more: true}) ==
                "<-- %News.HistoricalNewsEnd{request_id: 90001, has_more: true}"
     end
   end

--- a/test/ib_ex/client/messages/news/historical_news_test.exs
+++ b/test/ib_ex/client/messages/news/historical_news_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.HistoricalNews
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "creates HistoricalNews struct with valid fields" do
@@ -19,8 +20,8 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %HistoricalNews{
         request_id: "123",
         timestamp: "2021-12-31T23:59:59Z",
@@ -29,7 +30,7 @@ defmodule IbEx.Client.Messages.News.HistoricalNewsTest do
         headline: "Breaking News"
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %News.HistoricalNews{
                  request_id: 123,

--- a/test/ib_ex/client/messages/news/providers_test.exs
+++ b/test/ib_ex/client/messages/news/providers_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.ProvidersTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.Providers
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "creates the message with valid fields" do
@@ -21,13 +22,13 @@ defmodule IbEx.Client.Messages.News.ProvidersTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %Providers{
         items: [{"code1", "name1"}, {"code2", "name2"}]
       }
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                <-- %News.Providers{items: [{\"code1\", \"name1\"}, {\"code2\", \"name2\"}]}
                """

--- a/test/ib_ex/client/messages/news/request_article_test.exs
+++ b/test/ib_ex/client/messages/news/request_article_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.RequestArticleTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.RequestArticle
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/3" do
     test "creates a RequestArticle struct with valid inputs" do
@@ -28,15 +29,15 @@ defmodule IbEx.Client.Messages.News.RequestArticleTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects RequestArticle struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       request_article = %RequestArticle{
         request_id: 9001,
         provider_code: "BZ",
         provider_id: "BZ$12345abc"
       }
 
-      assert inspect(request_article) ==
+      assert Traceable.to_s(request_article) ==
                """
                <-- %News.RequestArticle{
                  request_id: 9001,

--- a/test/ib_ex/client/messages/news/request_historical_news_test.exs
+++ b/test/ib_ex/client/messages/news/request_historical_news_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.RequestHistoricalNewsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.RequestHistoricalNews
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/6" do
     test "creates the message with valid inputs" do
@@ -39,11 +40,11 @@ defmodule IbEx.Client.Messages.News.RequestHistoricalNewsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       msg = %RequestHistoricalNews{request_id: 90001, conid: 8314, provider_codes: "BRFG+BGRUPDN", max_results: 10}
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> News.RequestHistoricalNews{
                  request_id: 90001,

--- a/test/ib_ex/client/messages/news/request_news_bulletins_test.exs
+++ b/test/ib_ex/client/messages/news/request_news_bulletins_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.RequestBulletinsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.RequestBulletins
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/1" do
     test "creates the message with all_messages set to false by default" do
@@ -28,9 +29,9 @@ defmodule IbEx.Client.Messages.News.RequestBulletinsTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the struct" do
-      assert inspect(%RequestBulletins{all_messages: true}) == "--> News.RequestBulletins{all_messages: true}"
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
+      assert Traceable.to_s(%RequestBulletins{all_messages: true}) == "--> News.RequestBulletins{all_messages: true}"
     end
   end
 end

--- a/test/ib_ex/client/messages/news/request_providers_test.exs
+++ b/test/ib_ex/client/messages/news/request_providers_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.News.RequestProvidersTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.News.RequestProviders
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/0" do
     test "creates a RequestProviders struct with valid message id" do
@@ -15,10 +16,10 @@ defmodule IbEx.Client.Messages.News.RequestProvidersTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       request_providers = %RequestProviders{message_id: 1}
-      inspected = inspect(request_providers)
+      inspected = Traceable.to_s(request_providers)
 
       assert inspected == "--> News.RequestProviders{}"
     end

--- a/test/ib_ex/client/messages/orders/request_cancel_order_test.exs
+++ b/test/ib_ex/client/messages/orders/request_cancel_order_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.Orders.RequestCancelOrderTest do
   alias IbEx.Client.Types.OrderCancel
   alias IbEx.Client.Messages.Orders.RequestCancelOrder
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   describe "new/1" do
@@ -53,10 +54,10 @@ defmodule IbEx.Client.Messages.Orders.RequestCancelOrderTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects RequestCancelOrder struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %RequestCancelOrder{order_id: 1000}
-      assert inspect(msg) == "--> %MarketData.RequestCancelOrder{order_id: 1000}"
+      assert Traceable.to_s(msg) == "--> %MarketData.RequestCancelOrder{order_id: 1000}"
     end
   end
 

--- a/test/ib_ex/client/messages/orders/request_create_order_test.exs
+++ b/test/ib_ex/client/messages/orders/request_create_order_test.exs
@@ -4,6 +4,7 @@ defmodule IbEx.Client.Messages.Orders.RequestCreateOrderTest do
   alias IbEx.Client.Types.{Order, Contract}
   alias IbEx.Client.Messages.Orders.RequestCreateOrder
   alias IbEx.Client.Protocols.Subscribable
+  alias IbEx.Client.Protocols.Traceable
   alias IbEx.Client.Subscriptions
 
   @order_id 123
@@ -45,13 +46,13 @@ defmodule IbEx.Client.Messages.Orders.RequestCreateOrderTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspects RequestCreateOrder struct correctly" do
+  describe "Traceable" do
+    test "to_s/1 returns a human readable version of the message" do
       msg = %RequestCreateOrder{order_id: @order_id, order: @order, contract: @contract}
 
       contract_str = Enum.join(Contract.serialize(@contract, false), ", ")
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> RequestCreateOrder{
                  order_id: 123,

--- a/test/ib_ex/client/messages/pnl/all_positions_cancel_test.exs
+++ b/test/ib_ex/client/messages/pnl/all_positions_cancel_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsCancelTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.AllPositionsCancel
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/0" do
     test "creates a new AllPositionsCancel message with valid message id" do
@@ -12,11 +13,11 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsCancelTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/2 returns a human-readable version of the message" do
       {:ok, msg} = AllPositionsCancel.new("19001")
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> Pnl.AllPositionsCancel{message_id: 93, request_id: 19001}
                """

--- a/test/ib_ex/client/messages/pnl/all_positions_request_test.exs
+++ b/test/ib_ex/client/messages/pnl/all_positions_request_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsRequestTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.AllPositionsRequest
+  alias IbEx.Client.Protocols.Traceable
 
   @account_id "GU12345678"
   @request_id 70001
@@ -30,8 +31,8 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsRequestTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspect/2 returns the correct string representation" do
+  describe "Traceable" do
+    test "to_s/1 returns the correct string representation" do
       msg = %AllPositionsRequest{
         message_id: 92,
         request_id: @request_id,
@@ -39,7 +40,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsRequestTest do
         model_code: ""
       }
 
-      assert Inspect.inspect(msg, []) ==
+      assert Traceable.to_s(msg) ==
                """
                --> Pnl.AllPositionsRequest{
                  message_id: 92,

--- a/test/ib_ex/client/messages/pnl/all_positions_update_test.exs
+++ b/test/ib_ex/client/messages/pnl/all_positions_update_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsUpdateTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.AllPositionsUpdate
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "returns the parsed message with the PnL for the given position" do
@@ -18,8 +19,8 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsUpdateTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the struct" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
       pnl_single = %AllPositionsUpdate{
         request_id: "90001",
         daily_pnl: Decimal.new("-11.483693125"),
@@ -27,7 +28,7 @@ defmodule IbEx.Client.Messages.Pnl.AllPositionsUpdateTest do
         realized_pnl: Decimal.new("1.5298190129036")
       }
 
-      assert inspect(pnl_single) ==
+      assert Traceable.to_s(pnl_single) ==
                """
                <-- Pnl.AllPositionsUpdate{
                  request_id: 90001,

--- a/test/ib_ex/client/messages/pnl/single_position_cancel_test.exs
+++ b/test/ib_ex/client/messages/pnl/single_position_cancel_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionCancelTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.SinglePositionCancel
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/0" do
     test "creates a new SinglePositionCancel message with valid message id" do
@@ -12,11 +13,11 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionCancelTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = SinglePositionCancel.new("19001")
 
-      assert inspect(msg) ==
+      assert Traceable.to_s(msg) ==
                """
                --> Pnl.SinglePositionCancel{message_id: 95, request_id: 19001}
                """

--- a/test/ib_ex/client/messages/pnl/single_position_request_test.exs
+++ b/test/ib_ex/client/messages/pnl/single_position_request_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionRequestTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.SinglePositionRequest
+  alias IbEx.Client.Protocols.Traceable
 
   @apple_conid "265598"
   @account_id "GU12345678"
@@ -34,8 +35,8 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionRequestTest do
     end
   end
 
-  describe "Inspect implementation" do
-    test "inspect/2 returns the correct string representation" do
+  describe "Traceable" do
+    test "to_s/1 returns the correct string representation" do
       msg = %SinglePositionRequest{
         message_id: 94,
         request_id: @request_id,
@@ -44,7 +45,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionRequestTest do
         model_code: ""
       }
 
-      assert Inspect.inspect(msg, []) ==
+      assert Traceable.to_s(msg) ==
                """
                --> Pnl.SinglePositionRequest{
                  message_id: 94,

--- a/test/ib_ex/client/messages/pnl/single_position_update_test.exs
+++ b/test/ib_ex/client/messages/pnl/single_position_update_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdateTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.Pnl.SinglePositionUpdate
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_fields/1" do
     test "returns the parsed message with the PnL for the given position" do
@@ -21,8 +22,8 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdateTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the struct" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct" do
       pnl_single = %SinglePositionUpdate{
         request_id: "12345",
         position: "100",
@@ -32,7 +33,7 @@ defmodule IbEx.Client.Messages.Pnl.SinglePositionUpdateTest do
         value: Decimal.new("500")
       }
 
-      assert inspect(pnl_single) ==
+      assert Traceable.to_s(pnl_single) ==
                """
                <-- Pnl.SinglePositionUpdate{
                  request_id: 12345,

--- a/test/ib_ex/client/messages/start_api/request_test.exs
+++ b/test/ib_ex/client/messages/start_api/request_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.StartApi.RequestTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.StartApi.Request
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/1" do
     test "returns a StartApi Request message" do
@@ -22,11 +23,11 @@ defmodule IbEx.Client.Messages.StartApi.RequestTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = Request.new([])
 
-      assert inspect(msg) == "--> StartAPI{id: 71, version: 2, client_id: 0, opt_capabilities: []}"
+      assert Traceable.to_s(msg) == "--> StartAPI{id: 71, version: 2, client_id: 0, opt_capabilities: []}"
     end
   end
 end

--- a/test/ib_ex/client/messages/tick_by_tick_data/cancel_tick_by_tick_data_test.exs
+++ b/test/ib_ex/client/messages/tick_by_tick_data/cancel_tick_by_tick_data_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.TickByTickData.CancelTickByTickDataTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.TickByTickData.CancelTickByTickData
+  alias IbEx.Client.Protocols.Traceable
 
   describe "new/0" do
     test "creates a new CancelTickByTickData request with valid message id" do
@@ -16,10 +17,10 @@ defmodule IbEx.Client.Messages.TickByTickData.CancelTickByTickDataTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the message" do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the message" do
       {:ok, msg} = CancelTickByTickData.new(19001)
-      assert inspect(msg) == "--> CancelTickByTickData{message_id: 98, request_id: 19001}"
+      assert Traceable.to_s(msg) == "--> CancelTickByTickData{message_id: 98, request_id: 19001}"
     end
   end
 

--- a/test/ib_ex/client/messages/tick_by_tick_data/request_test.exs
+++ b/test/ib_ex/client/messages/tick_by_tick_data/request_test.exs
@@ -1,7 +1,9 @@
 defmodule IbEx.Client.Messages.TickByTickData.RequestTest do
   use ExUnit.Case, async: true
+
   alias IbEx.Client.Messages.TickByTickData.Request
   alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Protocols.Traceable
 
   setup do
     contract = %Contract{symbol: "AAPL", security_type: "STK", exchange: "NASDAQ", currency: "USD"}
@@ -47,11 +49,11 @@ defmodule IbEx.Client.Messages.TickByTickData.RequestTest do
     end
   end
 
-  describe "Inspect" do
-    test "inspect/2 returns a human-readable version of the struct", %{contract: contract} do
+  describe "Traceable" do
+    test "to_s/1 returns a human-readable version of the struct", %{contract: contract} do
       {:ok, msg} = Request.new(contract, 123, "Last", 10, true)
 
-      assert inspect(msg) == "-->
+      assert Traceable.to_s(msg) == "-->
         TickByTickData{
           message_id: 97,
           request_id: 123,

--- a/test/ib_ex/client/types/market_depth_description_test.exs
+++ b/test/ib_ex/client/types/market_depth_description_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Types.MarketDepthDescriptionTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Types.MarketDepthDescription
+  alias IbEx.Client.Protocols.Traceable
 
   describe "from_market_depth_exchanges/1" do
     test "creates a MarketDepthDescription with valid fields" do
@@ -20,8 +21,8 @@ defmodule IbEx.Client.Types.MarketDepthDescriptionTest do
     end
   end
 
-  describe "Inspect " do
-    test "inspect/2 returns the inspected struct" do
+  describe "Traceable" do
+    test "to_s/1 returns the inspected struct" do
       description = %MarketDepthDescription{
         exchange: "NYSE",
         security_type: "STK",
@@ -30,7 +31,7 @@ defmodule IbEx.Client.Types.MarketDepthDescriptionTest do
         aggregate_group: "1"
       }
 
-      assert inspect(description) == "%MarketDepthDescription{exchange: NYSE, security_type: STK}"
+      assert Traceable.to_s(description) == "%MarketDepthDescription{exchange: NYSE, security_type: STK}"
     end
   end
 end

--- a/test/ib_ex/client_test.exs
+++ b/test/ib_ex/client_test.exs
@@ -57,7 +57,7 @@ defmodule IbEx.ClientTest do
 
   describe "handle_cast/2 when processing an incoming message" do
     test "updates the client's state with the server version, the connection timestamp and continues to validate the server version" do
-      initial_state = %{status: :connecting}
+      initial_state = %{status: :connecting, trace_messages: false}
 
       str = "178\x0020240605 17:25:52 Central European Standard Time\x00"
 
@@ -83,7 +83,8 @@ defmodule IbEx.ClientTest do
 
       state = %{
         subscriptions_table_ref: table_ref,
-        status: :connected
+        status: :connected,
+        trace_messages: false
       }
 
       assert {:noreply, ^state} = Client.handle_cast({:process_message, @symbol_samples_msg_str}, state)


### PR DESCRIPTION
* Defines a custom protocol to trace the messages flow by printing them to console.
* Adds a flag to the client to print out the messages flow, hiding it by default