### PR TITLE
[507c8f0a] Add missing domain types for feature parity

### DIFF
--- a/lib/ib_ex/client/types/bar.ex
+++ b/lib/ib_ex/client/types/bar.ex
@@ -1,0 +1,37 @@
+defmodule IbEx.Client.Types.Bar do
+  @moduledoc """
+  Represents a single OHLCV bar from historical data responses.
+  """
+
+  defstruct time: nil,
+            open: nil,
+            high: nil,
+            low: nil,
+            close: nil,
+            volume: nil,
+            count: nil,
+            wap: nil
+
+  @type t :: %__MODULE__{
+          time: binary() | nil,
+          open: float() | nil,
+          high: float() | nil,
+          low: float() | nil,
+          close: float() | nil,
+          volume: Decimal.t() | nil,
+          count: non_neg_integer() | nil,
+          wap: Decimal.t() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/contract_details.ex
+++ b/lib/ib_ex/client/types/contract_details.ex
@@ -1,0 +1,111 @@
+defmodule IbEx.Client.Types.ContractDetails do
+  @moduledoc """
+  Represents the details of a contract as returned by the ContractDetails response.
+  """
+
+  alias IbEx.Client.Types.Contract
+  alias IbEx.Client.Types.TagValue
+
+  alias IbEx.Client.Types.ContractDetails.{
+    BondDetails,
+    FundDetails,
+    EventContract
+  }
+
+  defstruct contract: nil,
+            market_name: nil,
+            min_tick: 0.0,
+            order_types: nil,
+            valid_exchanges: nil,
+            price_magnifier: 0,
+            under_conid: 0,
+            long_name: nil,
+            contract_month: nil,
+            industry: nil,
+            category: nil,
+            subcategory: nil,
+            time_zone_id: nil,
+            trading_hours: nil,
+            liquid_hours: nil,
+            ev_rule: nil,
+            ev_multiplier: 0.0,
+            agg_group: 0,
+            under_symbol: nil,
+            under_sec_type: nil,
+            market_rule_ids: nil,
+            real_expiration_date: nil,
+            last_trade_time: nil,
+            stock_type: nil,
+            min_size: nil,
+            size_increment: nil,
+            suggested_size_increment: nil,
+            min_algo_size: nil,
+            sec_id_list: [],
+            ineligibility_reason_list: [],
+            bond_details: nil,
+            fund_details: nil,
+            event_contract: nil
+
+  @type t :: %__MODULE__{
+          contract: Contract.t() | nil,
+          market_name: binary() | nil,
+          min_tick: float(),
+          order_types: binary() | nil,
+          valid_exchanges: binary() | nil,
+          price_magnifier: non_neg_integer(),
+          under_conid: non_neg_integer(),
+          long_name: binary() | nil,
+          contract_month: binary() | nil,
+          industry: binary() | nil,
+          category: binary() | nil,
+          subcategory: binary() | nil,
+          time_zone_id: binary() | nil,
+          trading_hours: binary() | nil,
+          liquid_hours: binary() | nil,
+          ev_rule: binary() | nil,
+          ev_multiplier: float(),
+          agg_group: non_neg_integer(),
+          under_symbol: binary() | nil,
+          under_sec_type: binary() | nil,
+          market_rule_ids: binary() | nil,
+          real_expiration_date: binary() | nil,
+          last_trade_time: binary() | nil,
+          stock_type: binary() | nil,
+          min_size: Decimal.t() | nil,
+          size_increment: Decimal.t() | nil,
+          suggested_size_increment: Decimal.t() | nil,
+          min_algo_size: Decimal.t() | nil,
+          sec_id_list: list(TagValue.t()),
+          ineligibility_reason_list: list(binary()),
+          bond_details: BondDetails.t() | nil,
+          fund_details: FundDetails.t() | nil,
+          event_contract: EventContract.t() | nil
+        }
+
+  def new(attrs) when is_list(attrs) do
+    attrs
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(attrs) when is_map(attrs) do
+    attrs =
+      attrs
+      |> assign_params(:bond_details, BondDetails)
+      |> assign_params(:fund_details, FundDetails)
+      |> assign_params(:event_contract, EventContract)
+
+    struct(__MODULE__, attrs)
+  end
+
+  def new(), do: new(%{})
+
+  defp assign_params(attrs, key, module) do
+    case Map.get(attrs, key) do
+      nil -> attrs
+      value when is_map(value) -> Map.put(attrs, key, module.new(value))
+      %{__struct__: _} = value -> Map.put(attrs, key, value)
+      _ -> attrs
+    end
+  end
+end

--- a/lib/ib_ex/client/types/contract_details/bond_details.ex
+++ b/lib/ib_ex/client/types/contract_details/bond_details.ex
@@ -1,0 +1,51 @@
+defmodule IbEx.Client.Types.ContractDetails.BondDetails do
+  @moduledoc """
+  Bond-specific fields for a ContractDetails.
+  """
+
+  defstruct cusip: nil,
+            ratings: nil,
+            desc_append: nil,
+            bond_type: nil,
+            coupon_type: nil,
+            callable?: false,
+            putable?: false,
+            coupon: 0.0,
+            convertible?: false,
+            maturity: nil,
+            issue_date: nil,
+            next_option_date: nil,
+            next_option_type: nil,
+            next_option_partial?: false,
+            notes: nil
+
+  @type t :: %__MODULE__{
+          cusip: binary() | nil,
+          ratings: binary() | nil,
+          desc_append: binary() | nil,
+          bond_type: binary() | nil,
+          coupon_type: binary() | nil,
+          callable?: boolean(),
+          putable?: boolean(),
+          coupon: float(),
+          convertible?: boolean(),
+          maturity: binary() | nil,
+          issue_date: binary() | nil,
+          next_option_date: binary() | nil,
+          next_option_type: binary() | nil,
+          next_option_partial?: boolean(),
+          notes: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/contract_details/event_contract.ex
+++ b/lib/ib_ex/client/types/contract_details/event_contract.ex
@@ -1,0 +1,27 @@
+defmodule IbEx.Client.Types.ContractDetails.EventContract do
+  @moduledoc """
+  Event contract data associated with a ContractDetails.
+  """
+
+  defstruct contract_id: nil,
+            description_1: nil,
+            description_2: nil
+
+  @type t :: %__MODULE__{
+          contract_id: binary() | nil,
+          description_1: binary() | nil,
+          description_2: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/contract_details/fund_details.ex
+++ b/lib/ib_ex/client/types/contract_details/fund_details.ex
@@ -1,0 +1,84 @@
+defmodule IbEx.Client.Types.ContractDetails.FundDetails do
+  @moduledoc """
+  Mutual fund-specific fields for a ContractDetails.
+  """
+
+  import IbEx.Client.Utils, only: [list_to_union_type: 1]
+
+  @fund_asset_types ~w(others money_market fixed_income multi_asset equity sector guaranteed alternative)a
+  @type fund_asset_type :: unquote(list_to_union_type(@fund_asset_types))
+
+  @fund_asset_type_codes %{
+    "000" => :others,
+    "001" => :money_market,
+    "002" => :fixed_income,
+    "003" => :multi_asset,
+    "004" => :equity,
+    "005" => :sector,
+    "006" => :guaranteed,
+    "007" => :alternative
+  }
+
+  @fund_distribution_policies ~w(accumulation_fund income_fund)a
+  @type fund_distribution_policy :: unquote(list_to_union_type(@fund_distribution_policies))
+
+  @fund_distribution_policy_codes %{
+    "N" => :accumulation_fund,
+    "Y" => :income_fund
+  }
+
+  defstruct name: nil,
+            family: nil,
+            type: nil,
+            front_load: nil,
+            back_load: nil,
+            back_load_time_interval: nil,
+            management_fee: nil,
+            closed?: false,
+            closed_for_new_investors?: false,
+            closed_for_new_money?: false,
+            notify_amount: nil,
+            minimum_initial_purchase: nil,
+            subsequent_minimum_purchase: nil,
+            blue_sky_states: nil,
+            blue_sky_territories: nil,
+            distribution_policy_indicator: nil,
+            asset_type: nil
+
+  @type t :: %__MODULE__{
+          name: binary() | nil,
+          family: binary() | nil,
+          type: binary() | nil,
+          front_load: binary() | nil,
+          back_load: binary() | nil,
+          back_load_time_interval: binary() | nil,
+          management_fee: binary() | nil,
+          closed?: boolean(),
+          closed_for_new_investors?: boolean(),
+          closed_for_new_money?: boolean(),
+          notify_amount: binary() | nil,
+          minimum_initial_purchase: binary() | nil,
+          subsequent_minimum_purchase: binary() | nil,
+          blue_sky_states: binary() | nil,
+          blue_sky_territories: binary() | nil,
+          distribution_policy_indicator: fund_distribution_policy() | nil,
+          asset_type: fund_asset_type() | nil
+        }
+
+  def fund_asset_types, do: @fund_asset_types
+  def fund_asset_type_codes, do: @fund_asset_type_codes
+  def fund_distribution_policies, do: @fund_distribution_policies
+  def fund_distribution_policy_codes, do: @fund_distribution_policy_codes
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/execution.ex
+++ b/lib/ib_ex/client/types/execution.ex
@@ -3,6 +3,8 @@ defmodule IbEx.Client.Types.Execution do
   Represents a trade by the user
   """
 
+  import IbEx.Client.Utils, only: [list_to_union_type: 1]
+
   defstruct execution_id: "",
             timestamp: "",
             account_id: "",
@@ -21,7 +23,14 @@ defmodule IbEx.Client.Types.Execution do
             ev_multiplier: Decimal.new("0.0"),
             model_code: "",
             last_liquidity: 0,
-            pending_price_revision: false
+            pending_price_revision: false,
+            submitter: nil,
+            opt_exercise_or_lapse_type: nil
+
+  @option_exercise_types ~w(none exercise lapse)a
+  @type option_exercise_type :: unquote(list_to_union_type(@option_exercise_types))
+
+  def option_exercise_types, do: @option_exercise_types
 
   @type t :: %__MODULE__{
           execution_id: String.t(),
@@ -42,7 +51,9 @@ defmodule IbEx.Client.Types.Execution do
           ev_multiplier: float(),
           model_code: String.t(),
           last_liquidity: non_neg_integer(),
-          pending_price_revision: boolean()
+          pending_price_revision: boolean(),
+          submitter: binary() | nil,
+          opt_exercise_or_lapse_type: option_exercise_type() | nil
         }
 
   alias IbEx.Client.Utils

--- a/lib/ib_ex/client/types/executions_filter.ex
+++ b/lib/ib_ex/client/types/executions_filter.ex
@@ -19,10 +19,20 @@ defmodule IbEx.Client.Types.ExecutionsFilter do
           symbol: String.t() | nil,
           security_type: String.t() | nil,
           exchange: String.t() | nil,
-          side: String.t() | nil
+          side: String.t() | nil,
+          last_n_days: non_neg_integer() | nil,
+          specific_dates: list(String.t()) | nil
         }
 
-  defstruct client_id: nil, account_id: nil, time: nil, symbol: nil, security_type: nil, exchange: nil, side: nil
+  defstruct client_id: nil,
+            account_id: nil,
+            time: nil,
+            symbol: nil,
+            security_type: nil,
+            exchange: nil,
+            side: nil,
+            last_n_days: nil,
+            specific_dates: nil
 
   @spec new(Keyword.t()) :: {:ok, t} | {:error, :invalid_args}
   def new(opts) when is_list(opts) do
@@ -35,7 +45,9 @@ defmodule IbEx.Client.Types.ExecutionsFilter do
         symbol: Keyword.get(opts, :symbol),
         security_type: Keyword.get(opts, :security_type),
         exchange: Keyword.get(opts, :exchange),
-        side: Keyword.get(opts, :side)
+        side: Keyword.get(opts, :side),
+        last_n_days: Keyword.get(opts, :last_n_days),
+        specific_dates: Keyword.get(opts, :specific_dates)
       }
     }
   end

--- a/lib/ib_ex/client/types/family_code.ex
+++ b/lib/ib_ex/client/types/family_code.ex
@@ -1,0 +1,25 @@
+defmodule IbEx.Client.Types.FamilyCode do
+  @moduledoc """
+  Represents a family code that links accounts belonging to the same family.
+  """
+
+  defstruct account_id: nil,
+            family_code_str: nil
+
+  @type t :: %__MODULE__{
+          account_id: binary() | nil,
+          family_code_str: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/histogram_entry.ex
+++ b/lib/ib_ex/client/types/histogram_entry.ex
@@ -1,0 +1,25 @@
+defmodule IbEx.Client.Types.HistogramEntry do
+  @moduledoc """
+  Represents a single entry in a price histogram.
+  """
+
+  defstruct price: nil,
+            size: nil
+
+  @type t :: %__MODULE__{
+          price: float() | nil,
+          size: Decimal.t() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/historical_session.ex
+++ b/lib/ib_ex/client/types/historical_session.ex
@@ -1,0 +1,27 @@
+defmodule IbEx.Client.Types.HistoricalSession do
+  @moduledoc """
+  Represents a historical trading session with start and end times.
+  """
+
+  defstruct start_date_time: nil,
+            end_date_time: nil,
+            ref_date: nil
+
+  @type t :: %__MODULE__{
+          start_date_time: binary() | nil,
+          end_date_time: binary() | nil,
+          ref_date: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/historical_tick.ex
+++ b/lib/ib_ex/client/types/historical_tick.ex
@@ -1,0 +1,29 @@
+defmodule IbEx.Client.Types.HistoricalTick do
+  @moduledoc """
+  Represents a historical tick with timestamp and price data.
+
+  Used for midpoint historical tick requests.
+  """
+
+  defstruct time: nil,
+            price: nil,
+            size: nil
+
+  @type t :: %__MODULE__{
+          time: non_neg_integer() | nil,
+          price: float() | nil,
+          size: Decimal.t() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/historical_tick_bid_ask.ex
+++ b/lib/ib_ex/client/types/historical_tick_bid_ask.ex
@@ -1,0 +1,40 @@
+defmodule IbEx.Client.Types.HistoricalTickBidAsk do
+  @moduledoc """
+  Represents a historical bid/ask tick.
+
+  Tick attribute flags (ask_past_high, bid_past_low) are inlined directly
+  on the struct, matching the existing BidAsk type convention.
+  """
+
+  defstruct time: nil,
+            mask: nil,
+            bid_price: nil,
+            ask_price: nil,
+            bid_size: nil,
+            ask_size: nil,
+            ask_past_high: nil,
+            bid_past_low: nil
+
+  @type t :: %__MODULE__{
+          time: non_neg_integer() | nil,
+          mask: non_neg_integer() | nil,
+          bid_price: float() | nil,
+          ask_price: float() | nil,
+          bid_size: Decimal.t() | nil,
+          ask_size: Decimal.t() | nil,
+          ask_past_high: boolean() | nil,
+          bid_past_low: boolean() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/historical_tick_last.ex
+++ b/lib/ib_ex/client/types/historical_tick_last.ex
@@ -1,0 +1,40 @@
+defmodule IbEx.Client.Types.HistoricalTickLast do
+  @moduledoc """
+  Represents a historical last-traded tick.
+
+  Tick attribute flags (past_limit, unreported) are inlined directly
+  on the struct, matching the existing Trade type convention.
+  """
+
+  defstruct time: nil,
+            mask: nil,
+            price: nil,
+            size: nil,
+            exchange: nil,
+            conditions: nil,
+            past_limit: nil,
+            unreported: nil
+
+  @type t :: %__MODULE__{
+          time: non_neg_integer() | nil,
+          mask: non_neg_integer() | nil,
+          price: float() | nil,
+          size: Decimal.t() | nil,
+          exchange: binary() | nil,
+          conditions: binary() | nil,
+          past_limit: boolean() | nil,
+          unreported: boolean() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/ineligibility_reason.ex
+++ b/lib/ib_ex/client/types/ineligibility_reason.ex
@@ -1,0 +1,25 @@
+defmodule IbEx.Client.Types.IneligibilityReason do
+  @moduledoc """
+  Represents a reason why a contract or feature is ineligible.
+  """
+
+  defstruct id: nil,
+            description: nil
+
+  @type t :: %__MODULE__{
+          id: binary() | nil,
+          description: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/news_provider.ex
+++ b/lib/ib_ex/client/types/news_provider.ex
@@ -1,0 +1,28 @@
+defmodule IbEx.Client.Types.NewsProvider do
+  @moduledoc """
+  Represents a news provider with its code and name.
+
+  Extracted from the Messages.News.Providers response message to be
+  a proper domain type.
+  """
+
+  defstruct code: nil,
+            name: nil
+
+  @type t :: %__MODULE__{
+          code: binary() | nil,
+          name: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/order.ex
+++ b/lib/ib_ex/client/types/order.ex
@@ -117,7 +117,29 @@ defmodule IbEx.Client.Types.Order do
             customer_account: nil,
             professional_customer: false,
             external_user_id: nil,
-            manual_order_indicator: :unset_integer
+            manual_order_indicator: :unset_integer,
+            bond_accrued_interest: nil,
+            include_overnight: false,
+            submitter: nil,
+            post_only: false,
+            allow_pre_open: false,
+            ignore_open_auction: false,
+            deactivate: false,
+            seek_price_improvement: false,
+            what_if_type: nil,
+            sl_order_id: nil,
+            sl_order_type: nil,
+            pt_order_id: nil,
+            pt_order_type: nil,
+            filled_quantity: nil,
+            ref_futures_con_id: nil,
+            shareholder: nil,
+            imbalance_only: false,
+            route_marketable_to_bbo: false,
+            parent_perm_id: nil,
+            auto_cancel_date: nil,
+            active_start_time: nil,
+            active_stop_time: nil
 
   @times_in_force ~w(
    DAY GTC IOC GTD OPG FOK DTC
@@ -244,7 +266,29 @@ defmodule IbEx.Client.Types.Order do
           customer_account: binary(),
           professional_customer: boolean(),
           external_user_id: binary(),
-          manual_order_indicator: non_neg_integer()
+          manual_order_indicator: non_neg_integer(),
+          bond_accrued_interest: binary() | nil,
+          include_overnight: boolean(),
+          submitter: binary() | nil,
+          post_only: boolean(),
+          allow_pre_open: boolean(),
+          ignore_open_auction: boolean(),
+          deactivate: boolean(),
+          seek_price_improvement: boolean(),
+          what_if_type: non_neg_integer() | nil,
+          sl_order_id: non_neg_integer() | nil,
+          sl_order_type: binary() | nil,
+          pt_order_id: non_neg_integer() | nil,
+          pt_order_type: binary() | nil,
+          filled_quantity: Decimal.t() | nil,
+          ref_futures_con_id: non_neg_integer() | nil,
+          shareholder: binary() | nil,
+          imbalance_only: boolean(),
+          route_marketable_to_bbo: boolean(),
+          parent_perm_id: non_neg_integer() | nil,
+          auto_cancel_date: binary() | nil,
+          active_start_time: binary() | nil,
+          active_stop_time: binary() | nil
         }
 
   def new(attrs) when is_list(attrs) do

--- a/lib/ib_ex/client/types/order/condition/execution.ex
+++ b/lib/ib_ex/client/types/order/condition/execution.ex
@@ -1,0 +1,55 @@
+defmodule IbEx.Client.Types.Order.Condition.Execution do
+  @moduledoc """
+  Execution condition for an order.
+
+  Activates the order when a trade execution occurs on the specified
+  instrument. Unlike other conditions, execution conditions do not have
+  an `is_more` field since they trigger on the occurrence of any execution.
+
+  Fields:
+
+    * `sec_type` - The security type of the instrument (e.g., "STK", "OPT")
+    * `exchange` - The exchange where the execution is monitored
+    * `symbol` - The symbol of the instrument to monitor
+    * `conjunction` - How this condition combines with others (`:and` or `:or`)
+  """
+
+  @behaviour IbEx.Client.Types.Order.OrderCondition
+
+  defstruct sec_type: nil,
+            exchange: nil,
+            symbol: nil,
+            conjunction: :and
+
+  @type t :: %__MODULE__{
+          sec_type: binary() | nil,
+          exchange: binary() | nil,
+          symbol: binary() | nil,
+          conjunction: :and | :or
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+
+  @impl true
+  def type, do: :execution
+
+  @impl true
+  def to_proto(%__MODULE__{} = _condition) do
+    raise "not implemented"
+  end
+
+  @impl true
+  def from_proto(_proto) do
+    raise "not implemented"
+  end
+end

--- a/lib/ib_ex/client/types/order/condition/margin.ex
+++ b/lib/ib_ex/client/types/order/condition/margin.ex
@@ -1,0 +1,52 @@
+defmodule IbEx.Client.Types.Order.Condition.Margin do
+  @moduledoc """
+  Margin condition for an order.
+
+  Activates the order based on the account's margin cushion percentage.
+  The `is_more` field indicates whether the trigger fires when the margin
+  is above (`true`) or below (`false`) the specified percent.
+
+  Fields:
+
+    * `percent` - The margin cushion percentage threshold
+    * `is_more` - If `true`, triggers when margin is above; if `false`, when below
+    * `conjunction` - How this condition combines with others (`:and` or `:or`)
+  """
+
+  @behaviour IbEx.Client.Types.Order.OrderCondition
+
+  defstruct percent: nil,
+            is_more: nil,
+            conjunction: :and
+
+  @type t :: %__MODULE__{
+          percent: Decimal.t() | nil,
+          is_more: boolean() | nil,
+          conjunction: :and | :or
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+
+  @impl true
+  def type, do: :margin
+
+  @impl true
+  def to_proto(%__MODULE__{} = _condition) do
+    raise "not implemented"
+  end
+
+  @impl true
+  def from_proto(_proto) do
+    raise "not implemented"
+  end
+end

--- a/lib/ib_ex/client/types/order/condition/percent_change.ex
+++ b/lib/ib_ex/client/types/order/condition/percent_change.ex
@@ -1,0 +1,59 @@
+defmodule IbEx.Client.Types.Order.Condition.PercentChange do
+  @moduledoc """
+  Percent change condition for an order.
+
+  Activates the order when the percent change of the specified contract
+  reaches the given threshold. The `is_more` field indicates whether
+  the trigger fires when the change is above (`true`) or below (`false`)
+  the target.
+
+  Fields:
+
+    * `con_id` - Contract identifier for the instrument to monitor
+    * `exchange` - Exchange where the percent change is checked
+    * `change_percent` - The target percent change threshold
+    * `is_more` - If `true`, triggers when change is above; if `false`, when below
+    * `conjunction` - How this condition combines with others (`:and` or `:or`)
+  """
+
+  @behaviour IbEx.Client.Types.Order.OrderCondition
+
+  defstruct con_id: nil,
+            exchange: nil,
+            change_percent: nil,
+            is_more: nil,
+            conjunction: :and
+
+  @type t :: %__MODULE__{
+          con_id: non_neg_integer() | nil,
+          exchange: binary() | nil,
+          change_percent: Decimal.t() | nil,
+          is_more: boolean() | nil,
+          conjunction: :and | :or
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+
+  @impl true
+  def type, do: :percent_change
+
+  @impl true
+  def to_proto(%__MODULE__{} = _condition) do
+    raise "not implemented"
+  end
+
+  @impl true
+  def from_proto(_proto) do
+    raise "not implemented"
+  end
+end

--- a/lib/ib_ex/client/types/order/condition/price.ex
+++ b/lib/ib_ex/client/types/order/condition/price.ex
@@ -1,0 +1,61 @@
+defmodule IbEx.Client.Types.Order.Condition.Price do
+  @moduledoc """
+  Price condition for an order.
+
+  Activates the order when the price of the specified contract reaches
+  the given threshold. The `is_more` field indicates whether the trigger
+  fires when the price is above (`true`) or below (`false`) the target.
+
+  Fields:
+
+    * `con_id` - Contract identifier for the instrument to monitor
+    * `exchange` - Exchange where the price is checked
+    * `price` - The target price threshold
+    * `trigger_method` - How the price is determined (e.g., last, bid, ask)
+    * `is_more` - If `true`, triggers when price is above; if `false`, when below
+    * `conjunction` - How this condition combines with others (`:and` or `:or`)
+  """
+
+  @behaviour IbEx.Client.Types.Order.OrderCondition
+
+  defstruct con_id: nil,
+            exchange: nil,
+            price: nil,
+            trigger_method: nil,
+            is_more: nil,
+            conjunction: :and
+
+  @type t :: %__MODULE__{
+          con_id: non_neg_integer() | nil,
+          exchange: binary() | nil,
+          price: Decimal.t() | nil,
+          trigger_method: non_neg_integer() | nil,
+          is_more: boolean() | nil,
+          conjunction: :and | :or
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+
+  @impl true
+  def type, do: :price
+
+  @impl true
+  def to_proto(%__MODULE__{} = _condition) do
+    raise "not implemented"
+  end
+
+  @impl true
+  def from_proto(_proto) do
+    raise "not implemented"
+  end
+end

--- a/lib/ib_ex/client/types/order/condition/time.ex
+++ b/lib/ib_ex/client/types/order/condition/time.ex
@@ -1,0 +1,52 @@
+defmodule IbEx.Client.Types.Order.Condition.Time do
+  @moduledoc """
+  Time condition for an order.
+
+  Activates the order based on a time threshold. The `is_more` field
+  indicates whether the trigger fires after (`true`) or before (`false`)
+  the specified time.
+
+  Fields:
+
+    * `time` - The time threshold (formatted as yyyyMMdd HH:mm:ss timezone)
+    * `is_more` - If `true`, triggers after the time; if `false`, before
+    * `conjunction` - How this condition combines with others (`:and` or `:or`)
+  """
+
+  @behaviour IbEx.Client.Types.Order.OrderCondition
+
+  defstruct time: nil,
+            is_more: nil,
+            conjunction: :and
+
+  @type t :: %__MODULE__{
+          time: binary() | nil,
+          is_more: boolean() | nil,
+          conjunction: :and | :or
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+
+  @impl true
+  def type, do: :time
+
+  @impl true
+  def to_proto(%__MODULE__{} = _condition) do
+    raise "not implemented"
+  end
+
+  @impl true
+  def from_proto(_proto) do
+    raise "not implemented"
+  end
+end

--- a/lib/ib_ex/client/types/order/condition/volume.ex
+++ b/lib/ib_ex/client/types/order/condition/volume.ex
@@ -1,0 +1,58 @@
+defmodule IbEx.Client.Types.Order.Condition.Volume do
+  @moduledoc """
+  Volume condition for an order.
+
+  Activates the order when the volume of the specified contract reaches
+  the given threshold. The `is_more` field indicates whether the trigger
+  fires when volume is above (`true`) or below (`false`) the target.
+
+  Fields:
+
+    * `con_id` - Contract identifier for the instrument to monitor
+    * `exchange` - Exchange where the volume is checked
+    * `volume` - The target volume threshold
+    * `is_more` - If `true`, triggers when volume is above; if `false`, when below
+    * `conjunction` - How this condition combines with others (`:and` or `:or`)
+  """
+
+  @behaviour IbEx.Client.Types.Order.OrderCondition
+
+  defstruct con_id: nil,
+            exchange: nil,
+            volume: nil,
+            is_more: nil,
+            conjunction: :and
+
+  @type t :: %__MODULE__{
+          con_id: non_neg_integer() | nil,
+          exchange: binary() | nil,
+          volume: non_neg_integer() | nil,
+          is_more: boolean() | nil,
+          conjunction: :and | :or
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+
+  @impl true
+  def type, do: :volume
+
+  @impl true
+  def to_proto(%__MODULE__{} = _condition) do
+    raise "not implemented"
+  end
+
+  @impl true
+  def from_proto(_proto) do
+    raise "not implemented"
+  end
+end

--- a/lib/ib_ex/client/types/order/order_conditions_params.ex
+++ b/lib/ib_ex/client/types/order/order_conditions_params.ex
@@ -3,7 +3,6 @@ defmodule IbEx.Client.Types.Order.OrderConditionsParams do
   Serializes list of OrderCondition structs for Order serialization. 
   """
   alias IbEx.Client.Types.Order.OrderCondition
-  import IbEx.Client.Utils, only: [list_to_union_type: 1]
 
   defstruct conditions: [], conditions_cancel_order: false, conditions_ignore_rth: false
 
@@ -47,45 +46,55 @@ end
 
 defmodule IbEx.Client.Types.Order.OrderCondition do
   @moduledoc """
-  Implements the following OrderCondition types:
+  Behaviour for order condition types.
 
-    :price
-    :time
-    :margin
-    :execution
-    :volume
-    :percent_hange
+  Defines the contract that all condition types must implement.
+  Condition types determine when an order should be activated based on
+  price, time, margin, execution, volume, or percent change criteria.
 
+  Each condition also carries a `conjunction` field (`:and` or `:or`)
+  that defines how it combines with other conditions in a list.
+
+  ## Condition Types
+
+    * `:price` - Activates based on a contract's price
+    * `:time` - Activates based on time
+    * `:margin` - Activates based on margin cushion percentage
+    * `:execution` - Activates when an execution on a specified instrument occurs
+    * `:volume` - Activates based on a contract's volume
+    * `:percent_change` - Activates based on a contract's percent change
   """
+
   import IbEx.Client.Utils, only: [list_to_union_type: 1]
-  defstruct type: nil
 
   @condition_types ~w(price time margin execution volume percent_change)a
-  @type condition_types :: unquote(list_to_union_type(@condition_types))
+  @type condition_type :: unquote(list_to_union_type(@condition_types))
 
-  @type t :: %__MODULE__{
-          type: condition_types()
-        }
+  @type conjunction :: :and | :or
 
-  def new(args) when is_list(args) do
-    args
-    |> Enum.into(%{})
-    |> new()
-  end
+  @type t ::
+          IbEx.Client.Types.Order.Condition.Price.t()
+          | IbEx.Client.Types.Order.Condition.Time.t()
+          | IbEx.Client.Types.Order.Condition.Margin.t()
+          | IbEx.Client.Types.Order.Condition.Execution.t()
+          | IbEx.Client.Types.Order.Condition.Volume.t()
+          | IbEx.Client.Types.Order.Condition.PercentChange.t()
 
-  def new(args) when is_map(args) do
-    struct(__MODULE__, args)
-  end
+  @doc "Returns the condition type atom"
+  @callback type() :: condition_type()
 
-  def new(), do: new(%{})
+  @doc "Converts the condition struct into a protocol buffer representation"
+  @callback to_proto(struct()) :: map()
+
+  @doc "Builds a condition struct from a protocol buffer representation"
+  @callback from_proto(map()) :: struct()
+
+  @doc "Returns the list of valid condition type atoms"
+  def condition_types, do: @condition_types
 
   # TODO: implement
-  @spec serialize(__MODULE__.t()) :: list()
-  def serialize(%__MODULE__{type: :price}) do
-    []
-  end
-
-  def serialize(%__MODULE__{}) do
+  @spec serialize(t()) :: list()
+  def serialize(%{__struct__: _module}) do
     []
   end
 end

--- a/lib/ib_ex/client/types/order_allocation.ex
+++ b/lib/ib_ex/client/types/order_allocation.ex
@@ -1,0 +1,38 @@
+defmodule IbEx.Client.Types.OrderAllocation do
+  @moduledoc """
+  Represents a client allocation for a given order.
+
+  Includes information about the account, position changes, and allocation
+  quantities for financial advisor (FA) order allocations.
+  """
+
+  defstruct account: nil,
+            position: nil,
+            position_desired: nil,
+            position_after: nil,
+            desired_alloc_qty: nil,
+            allowed_alloc_qty: nil,
+            is_monetary: false
+
+  @type t :: %__MODULE__{
+          account: binary() | nil,
+          position: Decimal.t() | nil,
+          position_desired: Decimal.t() | nil,
+          position_after: Decimal.t() | nil,
+          desired_alloc_qty: Decimal.t() | nil,
+          allowed_alloc_qty: Decimal.t() | nil,
+          is_monetary: boolean()
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/order_state.ex
+++ b/lib/ib_ex/client/types/order_state.ex
@@ -1,0 +1,64 @@
+defmodule IbEx.Client.Types.OrderState do
+  @moduledoc """
+  Represents the current state of an order as returned by the OpenOrder response.
+
+  Contains order status, margin information (nested MarginInfo), commission
+  fields, and allocation details for financial advisor accounts.
+  """
+
+  alias IbEx.Client.Types.OrderState.MarginInfo
+  alias IbEx.Client.Types.OrderAllocation
+
+  defstruct status: nil,
+            margin: nil,
+            commission: nil,
+            min_commission: nil,
+            max_commission: nil,
+            commission_currency: nil,
+            suggested_size: nil,
+            reject_reason: nil,
+            warning_text: nil,
+            completed_time: nil,
+            completed_status: nil,
+            allocations: []
+
+  @type t :: %__MODULE__{
+          status: binary() | nil,
+          margin: MarginInfo.t() | nil,
+          commission: float() | nil,
+          min_commission: float() | nil,
+          max_commission: float() | nil,
+          commission_currency: binary() | nil,
+          suggested_size: Decimal.t() | nil,
+          reject_reason: binary() | nil,
+          warning_text: binary() | nil,
+          completed_time: binary() | nil,
+          completed_status: binary() | nil,
+          allocations: list(OrderAllocation.t())
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    attrs =
+      args
+      |> assign_params(:margin, MarginInfo)
+
+    struct(__MODULE__, attrs)
+  end
+
+  def new(), do: new(%{})
+
+  defp assign_params(attrs, key, module) do
+    case Map.get(attrs, key) do
+      nil -> attrs
+      %{__struct__: _} = value -> Map.put(attrs, key, value)
+      value when is_map(value) -> Map.put(attrs, key, module.new(value))
+      _ -> attrs
+    end
+  end
+end

--- a/lib/ib_ex/client/types/order_state/margin_info.ex
+++ b/lib/ib_ex/client/types/order_state/margin_info.ex
@@ -1,0 +1,61 @@
+defmodule IbEx.Client.Types.OrderState.MarginInfo do
+  @moduledoc """
+  Margin information associated with an OrderState.
+
+  Contains before/change/after values for initial margin, maintenance margin,
+  and equity with loan. Each metric has both a regular (RTH) variant and an
+  outside regular trading hours variant.
+  """
+
+  defstruct init_margin_before: nil,
+            init_margin_change: nil,
+            init_margin_after: nil,
+            maint_margin_before: nil,
+            maint_margin_change: nil,
+            maint_margin_after: nil,
+            equity_with_loan_before: nil,
+            equity_with_loan_change: nil,
+            equity_with_loan_after: nil,
+            init_margin_before_outside_rth: nil,
+            init_margin_change_outside_rth: nil,
+            init_margin_after_outside_rth: nil,
+            maint_margin_before_outside_rth: nil,
+            maint_margin_change_outside_rth: nil,
+            maint_margin_after_outside_rth: nil,
+            equity_with_loan_before_outside_rth: nil,
+            equity_with_loan_change_outside_rth: nil,
+            equity_with_loan_after_outside_rth: nil
+
+  @type t :: %__MODULE__{
+          init_margin_before: binary() | nil,
+          init_margin_change: binary() | nil,
+          init_margin_after: binary() | nil,
+          maint_margin_before: binary() | nil,
+          maint_margin_change: binary() | nil,
+          maint_margin_after: binary() | nil,
+          equity_with_loan_before: binary() | nil,
+          equity_with_loan_change: binary() | nil,
+          equity_with_loan_after: binary() | nil,
+          init_margin_before_outside_rth: binary() | nil,
+          init_margin_change_outside_rth: binary() | nil,
+          init_margin_after_outside_rth: binary() | nil,
+          maint_margin_before_outside_rth: binary() | nil,
+          maint_margin_change_outside_rth: binary() | nil,
+          maint_margin_after_outside_rth: binary() | nil,
+          equity_with_loan_before_outside_rth: binary() | nil,
+          equity_with_loan_change_outside_rth: binary() | nil,
+          equity_with_loan_after_outside_rth: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/price_increment.ex
+++ b/lib/ib_ex/client/types/price_increment.ex
@@ -1,0 +1,25 @@
+defmodule IbEx.Client.Types.PriceIncrement do
+  @moduledoc """
+  Represents a price increment rule for a given price range.
+  """
+
+  defstruct low_edge: nil,
+            increment: nil
+
+  @type t :: %__MODULE__{
+          low_edge: float() | nil,
+          increment: float() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/real_time_bar.ex
+++ b/lib/ib_ex/client/types/real_time_bar.ex
@@ -1,0 +1,39 @@
+defmodule IbEx.Client.Types.RealTimeBar do
+  @moduledoc """
+  Represents a real-time 5-second bar from the real-time bars subscription.
+  """
+
+  defstruct time: nil,
+            end_time: nil,
+            open: nil,
+            high: nil,
+            low: nil,
+            close: nil,
+            volume: nil,
+            count: nil,
+            wap: nil
+
+  @type t :: %__MODULE__{
+          time: binary() | nil,
+          end_time: binary() | nil,
+          open: float() | nil,
+          high: float() | nil,
+          low: float() | nil,
+          close: float() | nil,
+          volume: Decimal.t() | nil,
+          count: non_neg_integer() | nil,
+          wap: Decimal.t() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/scan_data.ex
+++ b/lib/ib_ex/client/types/scan_data.ex
@@ -1,0 +1,35 @@
+defmodule IbEx.Client.Types.ScanData do
+  @moduledoc """
+  Represents a single result row from a market scanner response.
+  """
+
+  alias IbEx.Client.Types.Contract
+
+  defstruct contract: nil,
+            rank: nil,
+            distance: nil,
+            benchmark: nil,
+            projection: nil,
+            legs_str: nil
+
+  @type t :: %__MODULE__{
+          contract: Contract.t() | nil,
+          rank: non_neg_integer() | nil,
+          distance: binary() | nil,
+          benchmark: binary() | nil,
+          projection: binary() | nil,
+          legs_str: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/scanner_subscription.ex
+++ b/lib/ib_ex/client/types/scanner_subscription.ex
@@ -1,0 +1,63 @@
+defmodule IbEx.Client.Types.ScannerSubscription do
+  @moduledoc """
+  Represents a scanner subscription with filter criteria for the market scanner.
+  """
+
+  defstruct number_of_rows: -1,
+            instrument: nil,
+            location_code: nil,
+            scan_code: nil,
+            above_price: nil,
+            below_price: nil,
+            above_volume: nil,
+            market_cap_above: nil,
+            market_cap_below: nil,
+            moody_rating_above: nil,
+            moody_rating_below: nil,
+            sp_rating_above: nil,
+            sp_rating_below: nil,
+            maturity_date_above: nil,
+            maturity_date_below: nil,
+            coupon_rate_above: nil,
+            coupon_rate_below: nil,
+            exclude_convertible: nil,
+            average_option_volume_above: nil,
+            scanner_setting_pairs: nil,
+            stock_type_filter: nil
+
+  @type t :: %__MODULE__{
+          number_of_rows: integer(),
+          instrument: binary() | nil,
+          location_code: binary() | nil,
+          scan_code: binary() | nil,
+          above_price: float() | nil,
+          below_price: float() | nil,
+          above_volume: non_neg_integer() | nil,
+          market_cap_above: float() | nil,
+          market_cap_below: float() | nil,
+          moody_rating_above: binary() | nil,
+          moody_rating_below: binary() | nil,
+          sp_rating_above: binary() | nil,
+          sp_rating_below: binary() | nil,
+          maturity_date_above: binary() | nil,
+          maturity_date_below: binary() | nil,
+          coupon_rate_above: float() | nil,
+          coupon_rate_below: float() | nil,
+          exclude_convertible: boolean() | nil,
+          average_option_volume_above: non_neg_integer() | nil,
+          scanner_setting_pairs: binary() | nil,
+          stock_type_filter: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/smart_component.ex
+++ b/lib/ib_ex/client/types/smart_component.ex
@@ -1,0 +1,27 @@
+defmodule IbEx.Client.Types.SmartComponent do
+  @moduledoc """
+  Represents a SMART routing component exchange with its letter and type.
+  """
+
+  defstruct bit_number: nil,
+            exchange: nil,
+            exchange_letter: nil
+
+  @type t :: %__MODULE__{
+          bit_number: non_neg_integer() | nil,
+          exchange: binary() | nil,
+          exchange_letter: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/lib/ib_ex/client/types/wsh_event_data.ex
+++ b/lib/ib_ex/client/types/wsh_event_data.ex
@@ -1,0 +1,23 @@
+defmodule IbEx.Client.Types.WshEventData do
+  @moduledoc """
+  Represents Wall Street Horizon event data for a contract.
+  """
+
+  defstruct data_json: nil
+
+  @type t :: %__MODULE__{
+          data_json: binary() | nil
+        }
+
+  def new(args) when is_list(args) do
+    args
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(args) when is_map(args) do
+    struct(__MODULE__, args)
+  end
+
+  def new(), do: new(%{})
+end

--- a/test/ib_ex/client/messages/executions/execution_data_test.exs
+++ b/test/ib_ex/client/messages/executions/execution_data_test.exs
@@ -110,7 +110,7 @@ defmodule IbEx.Client.Messages.Executions.ExecutionDataTest do
                <-- ExecutionData{
                  request_id: 1,
                  contract: %IbEx.Client.Types.Contract{conid: "520512263", symbol: "GTLB", security_type: "STK", last_trade_date_or_contract_month: "", strike: "0.0", right: "", multiplier: "", exchange: "ISLAND", currency: "USD", local_symbol: "GTLB", primary_exchange: "", trading_class: "", include_expired: false, security_id_type: "", security_id: "", combo_legs_description: nil, combo_legs: [], delta_neutral_contract: nil, description: "", issuer_id: ""},
-                 execution: %IbEx.Client.Types.Execution{execution_id: "00025b44.656e0e0c.01.01", timestamp: ~U[2023-12-04 21:39:34Z], account_id: "DU3494644", exchange: "ISLAND", side: "BOT", size: 100.0, price: 61.54, perm_id: 727593489, client_id: 0, order_id: "0", liquidation: 0, cumulative_quantity: Decimal.new("1600"), average_price: 61.496875, order_ref: "MktDepth", ev_rule: "", ev_multiplier: nil, model_code: "", last_liquidity: :add, pending_price_revision: false}
+                 execution: %IbEx.Client.Types.Execution{execution_id: "00025b44.656e0e0c.01.01", timestamp: ~U[2023-12-04 21:39:34Z], account_id: "DU3494644", exchange: "ISLAND", side: "BOT", size: 100.0, price: 61.54, perm_id: 727593489, client_id: 0, order_id: "0", liquidation: 0, cumulative_quantity: Decimal.new("1600"), average_price: 61.496875, order_ref: "MktDepth", ev_rule: "", ev_multiplier: nil, model_code: "", last_liquidity: :add, pending_price_revision: false, submitter: nil, opt_exercise_or_lapse_type: nil}
                }
                """
     end

--- a/test/ib_ex/client/messages/executions/request_test.exs
+++ b/test/ib_ex/client/messages/executions/request_test.exs
@@ -42,7 +42,7 @@ defmodule IbEx.Client.Messages.Executions.RequestTest do
                --> Executions.Request{
                  message_id: 7,
                  request_id: 90001,
-                 filter: %IbEx.Client.Types.ExecutionsFilter{client_id: 123, account_id: nil, time: nil, symbol: nil, security_type: nil, exchange: nil, side: nil}
+                 filter: %IbEx.Client.Types.ExecutionsFilter{client_id: 123, account_id: nil, time: nil, symbol: nil, security_type: nil, exchange: nil, side: nil, last_n_days: nil, specific_dates: nil}
                }
                """
     end

--- a/test/ib_ex/client/types/bar_test.exs
+++ b/test/ib_ex/client/types/bar_test.exs
@@ -1,0 +1,67 @@
+defmodule IbEx.Client.Types.BarTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.Bar
+
+  describe "new/0" do
+    test "creates a Bar struct with default attributes" do
+      assert Bar.new() == %Bar{
+               time: nil,
+               open: nil,
+               high: nil,
+               low: nil,
+               close: nil,
+               volume: nil,
+               count: nil,
+               wap: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a Bar struct from a map with valid attributes" do
+      params = %{
+        time: "20250115 10:30:00",
+        open: 150.25,
+        high: 151.00,
+        low: 149.50,
+        close: 150.75,
+        volume: Decimal.new("1000"),
+        count: 50,
+        wap: Decimal.new("150.50")
+      }
+
+      result = Bar.new(params)
+
+      assert result.time == "20250115 10:30:00"
+      assert result.open == 150.25
+      assert result.high == 151.00
+      assert result.low == 149.50
+      assert result.close == 150.75
+      assert result.volume == Decimal.new("1000")
+      assert result.count == 50
+      assert result.wap == Decimal.new("150.50")
+    end
+
+    test "creates a Bar struct from a keyword list" do
+      params = [
+        time: "20250115 10:30:00",
+        open: 150.25,
+        high: 151.00,
+        low: 149.50,
+        close: 150.75
+      ]
+
+      result = Bar.new(params)
+
+      assert result.time == "20250115 10:30:00"
+      assert result.open == 150.25
+      assert result.high == 151.00
+      assert result.low == 149.50
+      assert result.close == 150.75
+      assert result.volume == nil
+      assert result.count == nil
+      assert result.wap == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/execution_test.exs
+++ b/test/ib_ex/client/types/execution_test.exs
@@ -59,5 +59,40 @@ defmodule IbEx.Client.Types.ExecutionTest do
       invalid_fields = List.duplicate("invalid", 19)
       assert {:error, :invalid_args} == Execution.from_execution_data(invalid_fields)
     end
+
+    test "new fields default to nil" do
+      fields = [
+        "order123",
+        "exec123",
+        "20231204 22:39:34 Europe/Madrid",
+        "acc123",
+        "NYSE",
+        "BUY",
+        "100",
+        "61.54",
+        "727593489",
+        "0",
+        "0",
+        "100",
+        "61.54",
+        "ref123",
+        "rule1",
+        "2.0",
+        "modelABC",
+        "1",
+        "0"
+      ]
+
+      assert {:ok, execution} = Execution.from_execution_data(fields)
+
+      assert execution.submitter == nil
+      assert execution.opt_exercise_or_lapse_type == nil
+    end
+  end
+
+  describe "option_exercise_types/0" do
+    test "returns the list of option exercise type atoms" do
+      assert Execution.option_exercise_types() == [:none, :exercise, :lapse]
+    end
   end
 end

--- a/test/ib_ex/client/types/executions_filter_test.exs
+++ b/test/ib_ex/client/types/executions_filter_test.exs
@@ -52,6 +52,31 @@ defmodule IbEx.Client.Types.ExecutionsFilterTest do
       assert is_nil(filter.security_type)
       assert is_nil(filter.exchange)
       assert is_nil(filter.side)
+      assert is_nil(filter.last_n_days)
+      assert is_nil(filter.specific_dates)
+    end
+
+    test "creates an ExecutionsFilter with last_n_days" do
+      opts = [client_id: 123, last_n_days: 7]
+
+      {:ok, filter} = ExecutionsFilter.new(opts)
+
+      assert filter.client_id == 123
+      assert filter.last_n_days == 7
+      assert is_nil(filter.specific_dates)
+    end
+
+    test "creates an ExecutionsFilter with specific_dates" do
+      opts = [
+        account_id: "ABC123",
+        specific_dates: ["20250110", "20250111", "20250112"]
+      ]
+
+      {:ok, filter} = ExecutionsFilter.new(opts)
+
+      assert filter.account_id == "ABC123"
+      assert filter.specific_dates == ["20250110", "20250111", "20250112"]
+      assert is_nil(filter.last_n_days)
     end
   end
 end

--- a/test/ib_ex/client/types/family_code_test.exs
+++ b/test/ib_ex/client/types/family_code_test.exs
@@ -1,0 +1,34 @@
+defmodule IbEx.Client.Types.FamilyCodeTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.FamilyCode
+
+  describe "new/0" do
+    test "creates a FamilyCode struct with default attributes" do
+      assert FamilyCode.new() == %FamilyCode{
+               account_id: nil,
+               family_code_str: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a FamilyCode struct from a map" do
+      params = %{account_id: "DU12345", family_code_str: "FAM001"}
+
+      result = FamilyCode.new(params)
+
+      assert result.account_id == "DU12345"
+      assert result.family_code_str == "FAM001"
+    end
+
+    test "creates a FamilyCode struct from a keyword list" do
+      params = [account_id: "DU12345", family_code_str: "FAM001"]
+
+      result = FamilyCode.new(params)
+
+      assert result.account_id == "DU12345"
+      assert result.family_code_str == "FAM001"
+    end
+  end
+end

--- a/test/ib_ex/client/types/histogram_entry_test.exs
+++ b/test/ib_ex/client/types/histogram_entry_test.exs
@@ -1,0 +1,37 @@
+defmodule IbEx.Client.Types.HistogramEntryTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.HistogramEntry
+
+  describe "new/0" do
+    test "creates a HistogramEntry struct with default attributes" do
+      assert HistogramEntry.new() == %HistogramEntry{
+               price: nil,
+               size: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a HistogramEntry struct from a map" do
+      params = %{
+        price: 150.50,
+        size: Decimal.new("5000")
+      }
+
+      result = HistogramEntry.new(params)
+
+      assert result.price == 150.50
+      assert result.size == Decimal.new("5000")
+    end
+
+    test "creates a HistogramEntry struct from a keyword list" do
+      params = [price: 150.50]
+
+      result = HistogramEntry.new(params)
+
+      assert result.price == 150.50
+      assert result.size == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/historical_session_test.exs
+++ b/test/ib_ex/client/types/historical_session_test.exs
@@ -1,0 +1,44 @@
+defmodule IbEx.Client.Types.HistoricalSessionTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.HistoricalSession
+
+  describe "new/0" do
+    test "creates a HistoricalSession struct with default attributes" do
+      assert HistoricalSession.new() == %HistoricalSession{
+               start_date_time: nil,
+               end_date_time: nil,
+               ref_date: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a HistoricalSession struct from a map" do
+      params = %{
+        start_date_time: "20250115 09:30:00",
+        end_date_time: "20250115 16:00:00",
+        ref_date: "20250115"
+      }
+
+      result = HistoricalSession.new(params)
+
+      assert result.start_date_time == "20250115 09:30:00"
+      assert result.end_date_time == "20250115 16:00:00"
+      assert result.ref_date == "20250115"
+    end
+
+    test "creates a HistoricalSession struct from a keyword list" do
+      params = [
+        start_date_time: "20250115 09:30:00",
+        end_date_time: "20250115 16:00:00"
+      ]
+
+      result = HistoricalSession.new(params)
+
+      assert result.start_date_time == "20250115 09:30:00"
+      assert result.end_date_time == "20250115 16:00:00"
+      assert result.ref_date == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/historical_tick_bid_ask_test.exs
+++ b/test/ib_ex/client/types/historical_tick_bid_ask_test.exs
@@ -1,0 +1,63 @@
+defmodule IbEx.Client.Types.HistoricalTickBidAskTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.HistoricalTickBidAsk
+
+  describe "new/0" do
+    test "creates a HistoricalTickBidAsk struct with default attributes" do
+      assert HistoricalTickBidAsk.new() == %HistoricalTickBidAsk{
+               time: nil,
+               mask: nil,
+               bid_price: nil,
+               ask_price: nil,
+               bid_size: nil,
+               ask_size: nil,
+               ask_past_high: nil,
+               bid_past_low: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a HistoricalTickBidAsk struct from a map with all fields" do
+      params = %{
+        time: 1_704_067_200,
+        mask: 3,
+        bid_price: 150.00,
+        ask_price: 150.50,
+        bid_size: Decimal.new("200"),
+        ask_size: Decimal.new("300"),
+        ask_past_high: true,
+        bid_past_low: true
+      }
+
+      result = HistoricalTickBidAsk.new(params)
+
+      assert result.time == 1_704_067_200
+      assert result.mask == 3
+      assert result.bid_price == 150.00
+      assert result.ask_price == 150.50
+      assert result.bid_size == Decimal.new("200")
+      assert result.ask_size == Decimal.new("300")
+      assert result.ask_past_high == true
+      assert result.bid_past_low == true
+    end
+
+    test "creates a HistoricalTickBidAsk struct from a keyword list" do
+      params = [
+        time: 1_704_067_200,
+        bid_price: 150.00,
+        ask_price: 150.50
+      ]
+
+      result = HistoricalTickBidAsk.new(params)
+
+      assert result.time == 1_704_067_200
+      assert result.bid_price == 150.00
+      assert result.ask_price == 150.50
+      assert result.mask == nil
+      assert result.ask_past_high == nil
+      assert result.bid_past_low == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/historical_tick_last_test.exs
+++ b/test/ib_ex/client/types/historical_tick_last_test.exs
@@ -1,0 +1,63 @@
+defmodule IbEx.Client.Types.HistoricalTickLastTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.HistoricalTickLast
+
+  describe "new/0" do
+    test "creates a HistoricalTickLast struct with default attributes" do
+      assert HistoricalTickLast.new() == %HistoricalTickLast{
+               time: nil,
+               mask: nil,
+               price: nil,
+               size: nil,
+               exchange: nil,
+               conditions: nil,
+               past_limit: nil,
+               unreported: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a HistoricalTickLast struct from a map with all fields" do
+      params = %{
+        time: 1_704_067_200,
+        mask: 1,
+        price: 150.75,
+        size: Decimal.new("100"),
+        exchange: "NYSE",
+        conditions: "cond1",
+        past_limit: true,
+        unreported: false
+      }
+
+      result = HistoricalTickLast.new(params)
+
+      assert result.time == 1_704_067_200
+      assert result.mask == 1
+      assert result.price == 150.75
+      assert result.size == Decimal.new("100")
+      assert result.exchange == "NYSE"
+      assert result.conditions == "cond1"
+      assert result.past_limit == true
+      assert result.unreported == false
+    end
+
+    test "creates a HistoricalTickLast struct from a keyword list" do
+      params = [
+        time: 1_704_067_200,
+        price: 150.75,
+        exchange: "NYSE"
+      ]
+
+      result = HistoricalTickLast.new(params)
+
+      assert result.time == 1_704_067_200
+      assert result.price == 150.75
+      assert result.exchange == "NYSE"
+      assert result.mask == nil
+      assert result.past_limit == nil
+      assert result.unreported == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/historical_tick_test.exs
+++ b/test/ib_ex/client/types/historical_tick_test.exs
@@ -1,0 +1,41 @@
+defmodule IbEx.Client.Types.HistoricalTickTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.HistoricalTick
+
+  describe "new/0" do
+    test "creates a HistoricalTick struct with default attributes" do
+      assert HistoricalTick.new() == %HistoricalTick{
+               time: nil,
+               price: nil,
+               size: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a HistoricalTick struct from a map" do
+      params = %{
+        time: 1_704_067_200,
+        price: 150.25,
+        size: Decimal.new("100")
+      }
+
+      result = HistoricalTick.new(params)
+
+      assert result.time == 1_704_067_200
+      assert result.price == 150.25
+      assert result.size == Decimal.new("100")
+    end
+
+    test "creates a HistoricalTick struct from a keyword list" do
+      params = [time: 1_704_067_200, price: 150.25]
+
+      result = HistoricalTick.new(params)
+
+      assert result.time == 1_704_067_200
+      assert result.price == 150.25
+      assert result.size == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/ineligibility_reason_test.exs
+++ b/test/ib_ex/client/types/ineligibility_reason_test.exs
@@ -1,0 +1,34 @@
+defmodule IbEx.Client.Types.IneligibilityReasonTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.IneligibilityReason
+
+  describe "new/0" do
+    test "creates an IneligibilityReason struct with default attributes" do
+      assert IneligibilityReason.new() == %IneligibilityReason{
+               id: nil,
+               description: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates an IneligibilityReason struct from a map" do
+      params = %{id: "NO_SHORT", description: "Short selling not available"}
+
+      result = IneligibilityReason.new(params)
+
+      assert result.id == "NO_SHORT"
+      assert result.description == "Short selling not available"
+    end
+
+    test "creates an IneligibilityReason struct from a keyword list" do
+      params = [id: "NO_MARGIN", description: "Margin not available"]
+
+      result = IneligibilityReason.new(params)
+
+      assert result.id == "NO_MARGIN"
+      assert result.description == "Margin not available"
+    end
+  end
+end

--- a/test/ib_ex/client/types/news_provider_test.exs
+++ b/test/ib_ex/client/types/news_provider_test.exs
@@ -1,0 +1,34 @@
+defmodule IbEx.Client.Types.NewsProviderTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.NewsProvider
+
+  describe "new/0" do
+    test "creates a NewsProvider struct with default attributes" do
+      assert NewsProvider.new() == %NewsProvider{
+               code: nil,
+               name: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a NewsProvider struct from a map" do
+      params = %{code: "BRFG", name: "Briefing.com General Market Columns"}
+
+      result = NewsProvider.new(params)
+
+      assert result.code == "BRFG"
+      assert result.name == "Briefing.com General Market Columns"
+    end
+
+    test "creates a NewsProvider struct from a keyword list" do
+      params = [code: "DJNL", name: "Dow Jones Newsletters"]
+
+      result = NewsProvider.new(params)
+
+      assert result.code == "DJNL"
+      assert result.name == "Dow Jones Newsletters"
+    end
+  end
+end

--- a/test/ib_ex/client/types/order/order_conditions_params_test.exs
+++ b/test/ib_ex/client/types/order/order_conditions_params_test.exs
@@ -1,7 +1,7 @@
 defmodule IbEx.Client.Types.OrderConditionsParamsTest do
   use ExUnit.Case, async: true
 
-  alias IbEx.Client.Types.Order.OrderCondition
+  alias IbEx.Client.Types.Order.Condition.Price
   alias IbEx.Client.Types.Order.OrderConditionsParams
 
   describe "new/0" do
@@ -43,7 +43,7 @@ defmodule IbEx.Client.Types.OrderConditionsParamsTest do
 
     test "serializes for conditions != []" do
       params = %{
-        conditions: [OrderCondition.new()],
+        conditions: [Price.new()],
         conditions_cancel_order: true,
         conditions_ignore_rth: true
       }

--- a/test/ib_ex/client/types/order_allocation_test.exs
+++ b/test/ib_ex/client/types/order_allocation_test.exs
@@ -1,0 +1,76 @@
+defmodule IbEx.Client.Types.OrderAllocationTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.OrderAllocation
+
+  describe "new/0" do
+    test "creates an OrderAllocation struct with default attributes" do
+      assert OrderAllocation.new() == %OrderAllocation{
+               account: nil,
+               position: nil,
+               position_desired: nil,
+               position_after: nil,
+               desired_alloc_qty: nil,
+               allowed_alloc_qty: nil,
+               is_monetary: false
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates an OrderAllocation struct from a map with valid attributes" do
+      params = %{
+        account: "DU12345",
+        position: Decimal.new("100"),
+        position_desired: Decimal.new("150"),
+        position_after: Decimal.new("150"),
+        desired_alloc_qty: Decimal.new("50"),
+        allowed_alloc_qty: Decimal.new("50"),
+        is_monetary: false
+      }
+
+      result = OrderAllocation.new(params)
+
+      assert result.account == "DU12345"
+      assert result.position == Decimal.new("100")
+      assert result.position_desired == Decimal.new("150")
+      assert result.position_after == Decimal.new("150")
+      assert result.desired_alloc_qty == Decimal.new("50")
+      assert result.allowed_alloc_qty == Decimal.new("50")
+      assert result.is_monetary == false
+    end
+
+    test "creates an OrderAllocation struct with monetary allocation" do
+      params = %{
+        account: "DU67890",
+        position: Decimal.new("0"),
+        position_desired: Decimal.new("10000"),
+        position_after: Decimal.new("10000"),
+        desired_alloc_qty: Decimal.new("10000"),
+        allowed_alloc_qty: Decimal.new("10000"),
+        is_monetary: true
+      }
+
+      result = OrderAllocation.new(params)
+
+      assert result.account == "DU67890"
+      assert result.is_monetary == true
+      assert result.desired_alloc_qty == Decimal.new("10000")
+    end
+
+    test "creates an OrderAllocation struct from a keyword list" do
+      params = [
+        account: "DU12345",
+        position: Decimal.new("100"),
+        is_monetary: false
+      ]
+
+      result = OrderAllocation.new(params)
+
+      assert result.account == "DU12345"
+      assert result.position == Decimal.new("100")
+      assert result.is_monetary == false
+      assert result.position_desired == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/order_state/margin_info_test.exs
+++ b/test/ib_ex/client/types/order_state/margin_info_test.exs
@@ -1,0 +1,99 @@
+defmodule IbEx.Client.Types.OrderState.MarginInfoTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.OrderState.MarginInfo
+
+  describe "new/0" do
+    test "creates a MarginInfo struct with default attributes" do
+      assert MarginInfo.new() == %MarginInfo{
+               init_margin_before: nil,
+               init_margin_change: nil,
+               init_margin_after: nil,
+               maint_margin_before: nil,
+               maint_margin_change: nil,
+               maint_margin_after: nil,
+               equity_with_loan_before: nil,
+               equity_with_loan_change: nil,
+               equity_with_loan_after: nil,
+               init_margin_before_outside_rth: nil,
+               init_margin_change_outside_rth: nil,
+               init_margin_after_outside_rth: nil,
+               maint_margin_before_outside_rth: nil,
+               maint_margin_change_outside_rth: nil,
+               maint_margin_after_outside_rth: nil,
+               equity_with_loan_before_outside_rth: nil,
+               equity_with_loan_change_outside_rth: nil,
+               equity_with_loan_after_outside_rth: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a MarginInfo struct from a map with RTH margin values" do
+      params = %{
+        init_margin_before: "10000.00",
+        init_margin_change: "500.00",
+        init_margin_after: "10500.00",
+        maint_margin_before: "8000.00",
+        maint_margin_change: "400.00",
+        maint_margin_after: "8400.00",
+        equity_with_loan_before: "50000.00",
+        equity_with_loan_change: "-500.00",
+        equity_with_loan_after: "49500.00"
+      }
+
+      result = MarginInfo.new(params)
+
+      assert result.init_margin_before == "10000.00"
+      assert result.init_margin_change == "500.00"
+      assert result.init_margin_after == "10500.00"
+      assert result.maint_margin_before == "8000.00"
+      assert result.maint_margin_change == "400.00"
+      assert result.maint_margin_after == "8400.00"
+      assert result.equity_with_loan_before == "50000.00"
+      assert result.equity_with_loan_change == "-500.00"
+      assert result.equity_with_loan_after == "49500.00"
+    end
+
+    test "creates a MarginInfo struct from a map with outside RTH margin values" do
+      params = %{
+        init_margin_before_outside_rth: "12000.00",
+        init_margin_change_outside_rth: "600.00",
+        init_margin_after_outside_rth: "12600.00",
+        maint_margin_before_outside_rth: "9600.00",
+        maint_margin_change_outside_rth: "480.00",
+        maint_margin_after_outside_rth: "10080.00",
+        equity_with_loan_before_outside_rth: "50000.00",
+        equity_with_loan_change_outside_rth: "-600.00",
+        equity_with_loan_after_outside_rth: "49400.00"
+      }
+
+      result = MarginInfo.new(params)
+
+      assert result.init_margin_before_outside_rth == "12000.00"
+      assert result.init_margin_change_outside_rth == "600.00"
+      assert result.init_margin_after_outside_rth == "12600.00"
+      assert result.maint_margin_before_outside_rth == "9600.00"
+      assert result.maint_margin_change_outside_rth == "480.00"
+      assert result.maint_margin_after_outside_rth == "10080.00"
+      assert result.equity_with_loan_before_outside_rth == "50000.00"
+      assert result.equity_with_loan_change_outside_rth == "-600.00"
+      assert result.equity_with_loan_after_outside_rth == "49400.00"
+    end
+
+    test "creates a MarginInfo struct from a keyword list" do
+      params = [
+        init_margin_before: "10000.00",
+        maint_margin_before: "8000.00",
+        equity_with_loan_before: "50000.00"
+      ]
+
+      result = MarginInfo.new(params)
+
+      assert result.init_margin_before == "10000.00"
+      assert result.maint_margin_before == "8000.00"
+      assert result.equity_with_loan_before == "50000.00"
+      assert result.init_margin_change == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/order_state_test.exs
+++ b/test/ib_ex/client/types/order_state_test.exs
@@ -1,0 +1,137 @@
+defmodule IbEx.Client.Types.OrderStateTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.OrderState
+  alias IbEx.Client.Types.OrderState.MarginInfo
+  alias IbEx.Client.Types.OrderAllocation
+
+  describe "new/0" do
+    test "creates an OrderState struct with default attributes" do
+      assert OrderState.new() == %OrderState{
+               status: nil,
+               margin: nil,
+               commission: nil,
+               min_commission: nil,
+               max_commission: nil,
+               commission_currency: nil,
+               suggested_size: nil,
+               reject_reason: nil,
+               warning_text: nil,
+               completed_time: nil,
+               completed_status: nil,
+               allocations: []
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates an OrderState struct from a map with valid attributes" do
+      params = %{
+        status: "PreSubmitted",
+        commission: 1.75,
+        min_commission: 1.0,
+        max_commission: 2.5,
+        commission_currency: "USD",
+        suggested_size: Decimal.new("100"),
+        reject_reason: "",
+        warning_text: "Order will be held until market opens",
+        completed_time: "20250115 10:30:00",
+        completed_status: "Filled"
+      }
+
+      result = OrderState.new(params)
+
+      assert result.status == "PreSubmitted"
+      assert result.commission == 1.75
+      assert result.min_commission == 1.0
+      assert result.max_commission == 2.5
+      assert result.commission_currency == "USD"
+      assert result.suggested_size == Decimal.new("100")
+      assert result.reject_reason == ""
+      assert result.warning_text == "Order will be held until market opens"
+      assert result.completed_time == "20250115 10:30:00"
+      assert result.completed_status == "Filled"
+      assert result.allocations == []
+    end
+
+    test "creates an OrderState struct with nested MarginInfo from a map" do
+      params = %{
+        status: "Submitted",
+        margin: %{
+          init_margin_before: "10000.00",
+          init_margin_change: "500.00",
+          init_margin_after: "10500.00",
+          maint_margin_before: "8000.00",
+          maint_margin_change: "400.00",
+          maint_margin_after: "8400.00",
+          equity_with_loan_before: "50000.00",
+          equity_with_loan_change: "-500.00",
+          equity_with_loan_after: "49500.00"
+        }
+      }
+
+      result = OrderState.new(params)
+
+      assert result.status == "Submitted"
+      assert %MarginInfo{} = result.margin
+      assert result.margin.init_margin_before == "10000.00"
+      assert result.margin.init_margin_change == "500.00"
+      assert result.margin.init_margin_after == "10500.00"
+      assert result.margin.maint_margin_before == "8000.00"
+      assert result.margin.equity_with_loan_before == "50000.00"
+    end
+
+    test "preserves an existing MarginInfo struct when passed directly" do
+      margin = MarginInfo.new(%{init_margin_before: "15000.00"})
+
+      params = %{
+        status: "Submitted",
+        margin: margin
+      }
+
+      result = OrderState.new(params)
+
+      assert result.margin == margin
+      assert result.margin.init_margin_before == "15000.00"
+    end
+
+    test "creates an OrderState struct with allocations list" do
+      allocation_1 = OrderAllocation.new(%{account: "DU12345", position: Decimal.new("100")})
+      allocation_2 = OrderAllocation.new(%{account: "DU67890", position: Decimal.new("200")})
+
+      params = %{
+        status: "Submitted",
+        allocations: [allocation_1, allocation_2]
+      }
+
+      result = OrderState.new(params)
+
+      assert length(result.allocations) == 2
+      assert Enum.at(result.allocations, 0).account == "DU12345"
+      assert Enum.at(result.allocations, 1).account == "DU67890"
+    end
+
+    test "creates an OrderState struct from a keyword list" do
+      params = [
+        status: "PreSubmitted",
+        commission: 1.75,
+        commission_currency: "USD"
+      ]
+
+      result = OrderState.new(params)
+
+      assert result.status == "PreSubmitted"
+      assert result.commission == 1.75
+      assert result.commission_currency == "USD"
+      assert result.margin == nil
+    end
+
+    test "does not construct MarginInfo when margin is nil" do
+      params = %{status: "Submitted"}
+
+      result = OrderState.new(params)
+
+      assert result.margin == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/order_test.exs
+++ b/test/ib_ex/client/types/order_test.exs
@@ -120,7 +120,32 @@ defmodule IbEx.Client.Types.OrderTest do
                compete_against_best_offset: nil,
                mid_offset_at_whole: nil,
                mid_offset_at_half: nil,
-               customer_account: nil
+               customer_account: nil,
+               professional_customer: false,
+               external_user_id: nil,
+               manual_order_indicator: :unset_integer,
+               bond_accrued_interest: nil,
+               include_overnight: false,
+               submitter: nil,
+               post_only: false,
+               allow_pre_open: false,
+               ignore_open_auction: false,
+               deactivate: false,
+               seek_price_improvement: false,
+               what_if_type: nil,
+               sl_order_id: nil,
+               sl_order_type: nil,
+               pt_order_id: nil,
+               pt_order_type: nil,
+               filled_quantity: nil,
+               ref_futures_con_id: nil,
+               shareholder: nil,
+               imbalance_only: false,
+               route_marketable_to_bbo: false,
+               parent_perm_id: nil,
+               auto_cancel_date: nil,
+               active_start_time: nil,
+               active_stop_time: nil
              }
     end
   end

--- a/test/ib_ex/client/types/price_increment_test.exs
+++ b/test/ib_ex/client/types/price_increment_test.exs
@@ -1,0 +1,34 @@
+defmodule IbEx.Client.Types.PriceIncrementTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.PriceIncrement
+
+  describe "new/0" do
+    test "creates a PriceIncrement struct with default attributes" do
+      assert PriceIncrement.new() == %PriceIncrement{
+               low_edge: nil,
+               increment: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a PriceIncrement struct from a map" do
+      params = %{low_edge: 0.0, increment: 0.01}
+
+      result = PriceIncrement.new(params)
+
+      assert result.low_edge == 0.0
+      assert result.increment == 0.01
+    end
+
+    test "creates a PriceIncrement struct from a keyword list" do
+      params = [low_edge: 1.0, increment: 0.05]
+
+      result = PriceIncrement.new(params)
+
+      assert result.low_edge == 1.0
+      assert result.increment == 0.05
+    end
+  end
+end

--- a/test/ib_ex/client/types/real_time_bar_test.exs
+++ b/test/ib_ex/client/types/real_time_bar_test.exs
@@ -1,0 +1,68 @@
+defmodule IbEx.Client.Types.RealTimeBarTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.RealTimeBar
+
+  describe "new/0" do
+    test "creates a RealTimeBar struct with default attributes" do
+      assert RealTimeBar.new() == %RealTimeBar{
+               time: nil,
+               end_time: nil,
+               open: nil,
+               high: nil,
+               low: nil,
+               close: nil,
+               volume: nil,
+               count: nil,
+               wap: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a RealTimeBar struct from a map with valid attributes" do
+      params = %{
+        time: "20250115 10:30:00",
+        end_time: "20250115 10:30:05",
+        open: 150.25,
+        high: 151.00,
+        low: 149.50,
+        close: 150.75,
+        volume: Decimal.new("500"),
+        count: 25,
+        wap: Decimal.new("150.50")
+      }
+
+      result = RealTimeBar.new(params)
+
+      assert result.time == "20250115 10:30:00"
+      assert result.end_time == "20250115 10:30:05"
+      assert result.open == 150.25
+      assert result.high == 151.00
+      assert result.low == 149.50
+      assert result.close == 150.75
+      assert result.volume == Decimal.new("500")
+      assert result.count == 25
+      assert result.wap == Decimal.new("150.50")
+    end
+
+    test "creates a RealTimeBar struct from a keyword list" do
+      params = [
+        time: "20250115 10:30:00",
+        end_time: "20250115 10:30:05",
+        open: 150.25,
+        close: 150.75
+      ]
+
+      result = RealTimeBar.new(params)
+
+      assert result.time == "20250115 10:30:00"
+      assert result.end_time == "20250115 10:30:05"
+      assert result.open == 150.25
+      assert result.close == 150.75
+      assert result.high == nil
+      assert result.low == nil
+      assert result.volume == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/scan_data_test.exs
+++ b/test/ib_ex/client/types/scan_data_test.exs
@@ -1,0 +1,55 @@
+defmodule IbEx.Client.Types.ScanDataTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.ScanData
+  alias IbEx.Client.Types.Contract
+
+  describe "new/0" do
+    test "creates a ScanData struct with default attributes" do
+      assert ScanData.new() == %ScanData{
+               contract: nil,
+               rank: nil,
+               distance: nil,
+               benchmark: nil,
+               projection: nil,
+               legs_str: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a ScanData struct from a map with all fields" do
+      contract = %Contract{symbol: "AAPL", security_type: "STK"}
+
+      params = %{
+        contract: contract,
+        rank: 0,
+        distance: "5.2",
+        benchmark: "SPX",
+        projection: "1.5",
+        legs_str: "BUY 1 AAPL"
+      }
+
+      result = ScanData.new(params)
+
+      assert result.contract.symbol == "AAPL"
+      assert result.contract.security_type == "STK"
+      assert result.rank == 0
+      assert result.distance == "5.2"
+      assert result.benchmark == "SPX"
+      assert result.projection == "1.5"
+      assert result.legs_str == "BUY 1 AAPL"
+    end
+
+    test "creates a ScanData struct from a keyword list" do
+      params = [rank: 3, distance: "2.1"]
+
+      result = ScanData.new(params)
+
+      assert result.rank == 3
+      assert result.distance == "2.1"
+      assert result.contract == nil
+      assert result.benchmark == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/scanner_subscription_test.exs
+++ b/test/ib_ex/client/types/scanner_subscription_test.exs
@@ -1,0 +1,78 @@
+defmodule IbEx.Client.Types.ScannerSubscriptionTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.ScannerSubscription
+
+  describe "new/0" do
+    test "creates a ScannerSubscription struct with default attributes" do
+      result = ScannerSubscription.new()
+
+      assert result.number_of_rows == -1
+      assert result.instrument == nil
+      assert result.location_code == nil
+      assert result.scan_code == nil
+      assert result.above_price == nil
+      assert result.below_price == nil
+      assert result.above_volume == nil
+      assert result.market_cap_above == nil
+      assert result.market_cap_below == nil
+      assert result.moody_rating_above == nil
+      assert result.moody_rating_below == nil
+      assert result.sp_rating_above == nil
+      assert result.sp_rating_below == nil
+      assert result.maturity_date_above == nil
+      assert result.maturity_date_below == nil
+      assert result.coupon_rate_above == nil
+      assert result.coupon_rate_below == nil
+      assert result.exclude_convertible == nil
+      assert result.average_option_volume_above == nil
+      assert result.scanner_setting_pairs == nil
+      assert result.stock_type_filter == nil
+    end
+  end
+
+  describe "new/1" do
+    test "creates a ScannerSubscription struct from a map" do
+      params = %{
+        number_of_rows: 50,
+        instrument: "STK",
+        location_code: "STK.US.MAJOR",
+        scan_code: "TOP_PERC_GAIN",
+        above_price: 5.0,
+        below_price: 100.0,
+        above_volume: 1000,
+        market_cap_above: 1_000_000.0,
+        exclude_convertible: true,
+        stock_type_filter: "ALL"
+      }
+
+      result = ScannerSubscription.new(params)
+
+      assert result.number_of_rows == 50
+      assert result.instrument == "STK"
+      assert result.location_code == "STK.US.MAJOR"
+      assert result.scan_code == "TOP_PERC_GAIN"
+      assert result.above_price == 5.0
+      assert result.below_price == 100.0
+      assert result.above_volume == 1000
+      assert result.market_cap_above == 1_000_000.0
+      assert result.exclude_convertible == true
+      assert result.stock_type_filter == "ALL"
+    end
+
+    test "creates a ScannerSubscription struct from a keyword list" do
+      params = [
+        instrument: "STK",
+        scan_code: "HOT_BY_VOLUME",
+        number_of_rows: 25
+      ]
+
+      result = ScannerSubscription.new(params)
+
+      assert result.instrument == "STK"
+      assert result.scan_code == "HOT_BY_VOLUME"
+      assert result.number_of_rows == 25
+      assert result.location_code == nil
+    end
+  end
+end

--- a/test/ib_ex/client/types/smart_component_test.exs
+++ b/test/ib_ex/client/types/smart_component_test.exs
@@ -1,0 +1,37 @@
+defmodule IbEx.Client.Types.SmartComponentTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.SmartComponent
+
+  describe "new/0" do
+    test "creates a SmartComponent struct with default attributes" do
+      assert SmartComponent.new() == %SmartComponent{
+               bit_number: nil,
+               exchange: nil,
+               exchange_letter: nil
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "creates a SmartComponent struct from a map" do
+      params = %{bit_number: 0, exchange: "NYSE", exchange_letter: "N"}
+
+      result = SmartComponent.new(params)
+
+      assert result.bit_number == 0
+      assert result.exchange == "NYSE"
+      assert result.exchange_letter == "N"
+    end
+
+    test "creates a SmartComponent struct from a keyword list" do
+      params = [bit_number: 1, exchange: "ARCA", exchange_letter: "P"]
+
+      result = SmartComponent.new(params)
+
+      assert result.bit_number == 1
+      assert result.exchange == "ARCA"
+      assert result.exchange_letter == "P"
+    end
+  end
+end

--- a/test/ib_ex/client/types/wsh_event_data_test.exs
+++ b/test/ib_ex/client/types/wsh_event_data_test.exs
@@ -1,0 +1,31 @@
+defmodule IbEx.Client.Types.WshEventDataTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.WshEventData
+
+  describe "new/0" do
+    test "creates a WshEventData struct with default attributes" do
+      assert WshEventData.new() == %WshEventData{data_json: nil}
+    end
+  end
+
+  describe "new/1" do
+    test "creates a WshEventData struct from a map" do
+      json = ~s({"event_type":"earnings","date":"20250120"})
+      params = %{data_json: json}
+
+      result = WshEventData.new(params)
+
+      assert result.data_json == json
+    end
+
+    test "creates a WshEventData struct from a keyword list" do
+      json = ~s({"event_type":"dividend","date":"20250215"})
+      params = [data_json: json]
+
+      result = WshEventData.new(params)
+
+      assert result.data_json == json
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add ~30 domain types needed for feature parity with the canonical TWS API
- New types: ContractDetails (with BondDetails, FundDetails, EventContract sub-types), OrderState (with MarginInfo), OrderAllocation, Bar, RealTimeBar, HistoricalTick, HistoricalTickBidAsk, HistoricalTickLast, HistoricalSession, HistogramEntry, ScannerSubscription, ScanData, FamilyCode, PriceIncrement, SmartComponent, NewsProvider, WshEventData, IneligibilityReason
- Refactored Order.Condition into a behaviour with 6 concrete condition types: Price, Time, Margin, Execution, Volume, PercentChange
- Updated existing types with missing fields: Order (22 new fields), Execution (submitter, OptionExerciseType enum), ExecutionsFilter (last_n_days, specific_dates)

## Test plan

- [x] All new types have unit tests for `new/0` and `new/1` constructors (map and keyword list)
- [x] ContractDetails tests verify nested sub-type construction
- [x] Order.Condition subtypes tested for correct type atoms
- [x] Updated types have tests covering new fields
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] 426 tests, 0 failures