### PR TITLE
[14581df0] Add protobuf support to connection layer

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -108,7 +108,7 @@ defmodule IbEx.Client do
   def handle_continue(:init_connection, state) do
     {:ok, msg} = Messages.InitConnection.Request.new()
 
-    Connection.send_message(state.connection, msg)
+    Connection.send_message(state.connection, to_string(msg))
     Connection.set_packet_mode_on(state.connection)
 
     {:noreply, %{state | status: :connecting}}
@@ -117,7 +117,7 @@ defmodule IbEx.Client do
       {:stop, {:error_initializing_connection, err}}
   end
 
-  @min_version_tag :pending_price_revision
+  @min_version_tag :protobuf_rest_messages_3
 
   def handle_continue(:validate_server_version, state) do
     case validate_server_version_for(@min_version_tag, state) do
@@ -136,7 +136,8 @@ defmodule IbEx.Client do
     ]
 
     {:ok, start_api_msg} = Messages.StartApi.Request.new(msg_opts)
-    Connection.send_message(state.connection, start_api_msg)
+    {:ok, encoded} = Messages.Requests.encode_request(start_api_msg)
+    Connection.send_message(state.connection, encoded)
 
     {:noreply, state}
   rescue
@@ -182,7 +183,8 @@ defmodule IbEx.Client do
           Logger.info(Traceable.to_s(msg))
         end
 
-        Connection.send_message(state.connection, msg)
+        {:ok, encoded} = Messages.Requests.encode_request(msg)
+        Connection.send_message(state.connection, encoded)
 
       _ ->
         Logger.error("Error sending out message: #{request}")

--- a/lib/ib_ex/client/connection.ex
+++ b/lib/ib_ex/client/connection.ex
@@ -69,8 +69,8 @@ defmodule IbEx.Client.Connection do
   end
 
   @impl true
-  def handle_call({:send_message, msg}, _from, state) do
-    Socket.send_message(state.socket, to_string(msg))
+  def handle_call({:send_message, data}, _from, state) do
+    Socket.send_message(state.socket, data)
 
     {:reply, :ok, state}
   end

--- a/lib/ib_ex/client/constants/server_versions.ex
+++ b/lib/ib_ex/client/constants/server_versions.ex
@@ -127,11 +127,37 @@ defmodule IbEx.Client.Constants.ServerVersions do
     professional_customer: 184,
     bond_accrued_interest: 185,
     ineligibility_reasons: 186,
-    rfq_fields: 187
+    rfq_fields: 187,
+    bond_trading_hours: 188,
+    include_overnight: 189,
+    undo_rfq_fields: 190,
+    perm_id_as_long: 191,
+    cme_tagging_fields: 192,
+    cme_tagging_fields_in_open_order: 193,
+    error_time: 194,
+    full_order_preview_fields: 195,
+    historical_data_end: 196,
+    current_time_in_millis: 197,
+    submitter: 198,
+    imbalance_only: 199,
+    parametrized_days_of_executions: 200,
+    protobuf: 201,
+    zero_strike: 202,
+    protobuf_place_order: 203,
+    protobuf_completed_order: 204,
+    protobuf_contract_data: 205,
+    protobuf_market_data: 206,
+    protobuf_accounts_positions: 207,
+    protobuf_historical_data: 208,
+    protobuf_news_data: 209,
+    protobuf_scan_data: 210,
+    protobuf_rest_messages_1: 211,
+    protobuf_rest_messages_2: 212,
+    protobuf_rest_messages_3: 213
   ]
 
   @min_client_ver 100
-  @max_client_ver :rfq_fields
+  @max_client_ver :protobuf_rest_messages_3
 
   def version_for(key) do
     Keyword.fetch(@versions, key)

--- a/lib/ib_ex/client/messages/error_info/base.ex
+++ b/lib/ib_ex/client/messages/error_info/base.ex
@@ -4,6 +4,26 @@ defmodule IbEx.Client.Messages.ErrorInfo.Base do
 
   require Logger
 
+  def from_protobuf(payload) when is_binary(payload) do
+    proto = IbEx.Client.Proto.Protobuf.ErrorMessage.decode(payload)
+
+    msg = %{
+      id: proto.id,
+      code: proto.error_code,
+      message: proto.error_msg
+    }
+
+    if proto.id == -1 do
+      {:ok, struct(Info, msg)}
+    else
+      {:ok, struct(Error, msg)}
+    end
+  rescue
+    err ->
+      Logger.warning("Error decoding ErrorMessage protobuf: #{inspect(err)}")
+      {:error, :decode_error}
+  end
+
   def from_fieds([version_str, msg] = fields) do
     case Integer.parse(version_str) do
       {version, _} ->

--- a/lib/ib_ex/client/messages/ids/next_valid_id.ex
+++ b/lib/ib_ex/client/messages/ids/next_valid_id.ex
@@ -7,6 +7,16 @@ defmodule IbEx.Client.Messages.Ids.NextValidId do
 
   defstruct version: nil, next_valid_id: nil
 
+  def from_protobuf(payload) when is_binary(payload) do
+    proto = IbEx.Client.Proto.Protobuf.NextValidId.decode(payload)
+
+    {:ok, %__MODULE__{next_valid_id: proto.order_id}}
+  rescue
+    err ->
+      Logger.warning("Error decoding NextValidId protobuf: #{inspect(err)}")
+      {:error, :decode_error}
+  end
+
   def from_fields([version_str, id_str]) do
     with {version, _} <- Integer.parse(version_str),
          {id, _} <- Integer.parse(id_str) do

--- a/lib/ib_ex/client/messages/matching_symbols/request.ex
+++ b/lib/ib_ex/client/messages/matching_symbols/request.ex
@@ -20,6 +20,20 @@ defmodule IbEx.Client.Messages.MatchingSymbols.Request do
     end
   end
 
+  def to_protobuf(%__MODULE__{} = msg) do
+    req_id =
+      case msg.request_id do
+        id when is_integer(id) -> id
+        id when is_binary(id) -> String.to_integer(id)
+      end
+
+    %IbEx.Client.Proto.Protobuf.MatchingSymbolsRequest{
+      req_id: req_id,
+      pattern: msg.pattern
+    }
+    |> Protobuf.encode()
+  end
+
   defimpl String.Chars, for: __MODULE__ do
     alias IbEx.Client.Messages.Base
 

--- a/lib/ib_ex/client/messages/misc/managed_accounts.ex
+++ b/lib/ib_ex/client/messages/misc/managed_accounts.ex
@@ -5,6 +5,16 @@ defmodule IbEx.Client.Messages.Misc.ManagedAccounts do
 
   defstruct version: nil, accounts: nil
 
+  def from_protobuf(payload) when is_binary(payload) do
+    proto = IbEx.Client.Proto.Protobuf.ManagedAccounts.decode(payload)
+
+    {:ok, %__MODULE__{accounts: proto.accounts_list}}
+  rescue
+    err ->
+      Logger.warning("Error decoding ManagedAccounts protobuf: #{inspect(err)}")
+      {:error, :decode_error}
+  end
+
   def from_fields([version, accounts]) do
     msg = %__MODULE__{
       version: String.to_integer(version),

--- a/lib/ib_ex/client/messages/requests.ex
+++ b/lib/ib_ex/client/messages/requests.ex
@@ -84,8 +84,20 @@ defmodule IbEx.Client.Messages.Requests do
     "user_info" => 104
   }
 
+  @protobuf_offset 200
+
   @spec message_id_for(atom()) :: {:ok, non_neg_integer()} | :error
   def message_id_for(atom) do
     Map.fetch(@message_ids, atom)
+  end
+
+  @spec encode_request(struct()) :: {:ok, binary()} | :error
+  def encode_request(%module{} = request) do
+    with {:ok, msg_id} <- message_id_for(module) do
+      wire_id = msg_id + @protobuf_offset
+      payload = module.to_protobuf(request)
+
+      {:ok, <<wire_id::big-integer-size(32), payload::binary>>}
+    end
   end
 end

--- a/lib/ib_ex/client/messages/responses.ex
+++ b/lib/ib_ex/client/messages/responses.ex
@@ -5,92 +5,94 @@ defmodule IbEx.Client.Messages.Responses do
 
   require Logger
 
+  @protobuf_offset 200
+
   @ids_to_message_type %{
-    "1" => Messages.MarketData.TickPrice,
-    "2" => Messages.MarketData.TickSize,
-    "3" => Messages.Orders.Status,
-    "4" => Messages.ErrorInfo.Base,
-    "5" => Messages.Orders.OpenOrder,
-    "6" => Messages.AccountData.AccountDetail,
-    "7" => "portfolio_value",
-    "8" => Messages.AccountData.AccountUpdateTime,
-    "9" => Messages.Ids.NextValidId,
-    "10" => "contract_data",
-    "11" => Messages.Executions.ExecutionData,
-    "12" => Messages.MarketDepth.L2DataSingle,
-    "13" => Messages.MarketDepth.L2DataMultiple,
-    "14" => Messages.News.Bulletins,
-    "15" => Messages.Misc.ManagedAccounts,
-    "16" => "receive_fa",
-    "17" => "historical_data",
-    "18" => "bond_contract_data",
-    "19" => "scanner_parameters",
-    "20" => "scanner_data",
-    "21" => "tick_option_computation",
-    "45" => Messages.MarketData.TickGeneric,
-    "46" => Messages.MarketData.TickString,
-    "47" => "tick_efp",
-    "49" => Messages.CurrentTime.Response,
-    "50" => "real_time_bars",
-    "51" => "fundamental_data",
-    "52" => "contract_data_end",
-    "53" => "open_order_end",
-    "54" => Messages.AccountData.AccountDownloadEnd,
-    "55" => Messages.Executions.ExecutionDataEnd,
-    "56" => "deta_neutral_validation",
-    "57" => "tick_snapshot_end",
-    "58" => Messages.MarketData.MarketDataType,
-    "59" => Messages.Executions.CommissionReport,
-    "61" => "position_data",
-    "62" => "position_end",
-    "63" => "account_summary",
-    "64" => "account_summary_end",
-    "65" => "verify_message_api",
-    "66" => "verify_completed",
-    "67" => "display_group_list",
-    "68" => "display_group_updated",
-    "69" => "verify_and_auth_message_api",
-    "70" => "verify_and_auth_completed",
-    "71" => "position_multi",
-    "72" => "position_multi_end",
-    "73" => "account_update_multi",
-    "74" => "account_update_multi_end",
-    "75" => Messages.MarketData.OptionChain,
-    "76" => Messages.MarketData.OptionChainEnd,
-    "77" => "soft_dollar_tiers",
-    "78" => "family_codes",
-    "79" => Messages.MatchingSymbols.SymbolSamples,
-    "80" => Messages.MarketDepth.Exchanges,
-    "81" => Messages.MarketData.TickRequestParams,
-    "82" => "smart_components",
-    "83" => Messages.News.ArticleData,
-    "84" => Messages.MarketData.TickNews,
-    "85" => Messages.News.Providers,
-    "86" => Messages.News.HistoricalNews,
-    "87" => Messages.News.HistoricalNewsEnd,
-    "88" => "head_timestamp",
-    "89" => "histogram_data",
-    "90" => "historical_data_update",
-    "91" => "reroute_mkt_data_req",
-    "92" => "reroute_mkt_depth_req",
-    "93" => "market_rule",
-    "94" => Messages.Pnl.AllPositionsUpdate,
-    "95" => Messages.Pnl.SinglePositionUpdate,
-    "96" => "historical_ticks",
-    "97" => "historical_ticks_bid_ask",
-    "98" => Messages.HistoricalTicks.Last,
-    "99" => Messages.TickByTickData.TickByTick,
-    "100" => "order_bound",
-    "101" => "completed_orders",
-    "102" => "completed_orders_end",
-    "103" => "replace_fa_end",
-    "104" => "wsh_meta_data",
-    "105" => "wsh_event_data",
-    "106" => "historical_schedule",
-    "107" => "user_info"
+    1 => Messages.MarketData.TickPrice,
+    2 => Messages.MarketData.TickSize,
+    3 => Messages.Orders.Status,
+    4 => Messages.ErrorInfo.Base,
+    5 => Messages.Orders.OpenOrder,
+    6 => Messages.AccountData.AccountDetail,
+    7 => "portfolio_value",
+    8 => Messages.AccountData.AccountUpdateTime,
+    9 => Messages.Ids.NextValidId,
+    10 => "contract_data",
+    11 => Messages.Executions.ExecutionData,
+    12 => Messages.MarketDepth.L2DataSingle,
+    13 => Messages.MarketDepth.L2DataMultiple,
+    14 => Messages.News.Bulletins,
+    15 => Messages.Misc.ManagedAccounts,
+    16 => "receive_fa",
+    17 => "historical_data",
+    18 => "bond_contract_data",
+    19 => "scanner_parameters",
+    20 => "scanner_data",
+    21 => "tick_option_computation",
+    45 => Messages.MarketData.TickGeneric,
+    46 => Messages.MarketData.TickString,
+    47 => "tick_efp",
+    49 => Messages.CurrentTime.Response,
+    50 => "real_time_bars",
+    51 => "fundamental_data",
+    52 => "contract_data_end",
+    53 => "open_order_end",
+    54 => Messages.AccountData.AccountDownloadEnd,
+    55 => Messages.Executions.ExecutionDataEnd,
+    56 => "deta_neutral_validation",
+    57 => "tick_snapshot_end",
+    58 => Messages.MarketData.MarketDataType,
+    59 => Messages.Executions.CommissionReport,
+    61 => "position_data",
+    62 => "position_end",
+    63 => "account_summary",
+    64 => "account_summary_end",
+    65 => "verify_message_api",
+    66 => "verify_completed",
+    67 => "display_group_list",
+    68 => "display_group_updated",
+    69 => "verify_and_auth_message_api",
+    70 => "verify_and_auth_completed",
+    71 => "position_multi",
+    72 => "position_multi_end",
+    73 => "account_update_multi",
+    74 => "account_update_multi_end",
+    75 => Messages.MarketData.OptionChain,
+    76 => Messages.MarketData.OptionChainEnd,
+    77 => "soft_dollar_tiers",
+    78 => "family_codes",
+    79 => Messages.MatchingSymbols.SymbolSamples,
+    80 => Messages.MarketDepth.Exchanges,
+    81 => Messages.MarketData.TickRequestParams,
+    82 => "smart_components",
+    83 => Messages.News.ArticleData,
+    84 => Messages.MarketData.TickNews,
+    85 => Messages.News.Providers,
+    86 => Messages.News.HistoricalNews,
+    87 => Messages.News.HistoricalNewsEnd,
+    88 => "head_timestamp",
+    89 => "histogram_data",
+    90 => "historical_data_update",
+    91 => "reroute_mkt_data_req",
+    92 => "reroute_mkt_depth_req",
+    93 => "market_rule",
+    94 => Messages.Pnl.AllPositionsUpdate,
+    95 => Messages.Pnl.SinglePositionUpdate,
+    96 => "historical_ticks",
+    97 => "historical_ticks_bid_ask",
+    98 => Messages.HistoricalTicks.Last,
+    99 => Messages.TickByTickData.TickByTick,
+    100 => "order_bound",
+    101 => "completed_orders",
+    102 => "completed_orders_end",
+    103 => "replace_fa_end",
+    104 => "wsh_meta_data",
+    105 => "wsh_event_data",
+    106 => "historical_schedule",
+    107 => "user_info"
   }
 
-  @spec parse(String.t(), atom(), boolean()) :: {:ok, any()} | {:error, :unexpected_error} | {:error, :not_implemented}
+  @spec parse(binary(), atom(), boolean()) :: {:ok, any()} | {:error, :unexpected_error} | {:error, :not_implemented}
   def parse(str, :connecting, trace_messages) do
     {:ok, msg} =
       str
@@ -104,27 +106,27 @@ defmodule IbEx.Client.Messages.Responses do
     {:ok, msg}
   end
 
-  def parse(str, _, trace_messages) do
-    with fields <- Base.get_fields(str),
-         {:ok, msg_id} <- Base.message_id_from_fields(fields),
-         {:ok, type} <- Map.fetch(@ids_to_message_type, msg_id),
+  def parse(<<raw_msg_id::big-integer-size(32), payload::binary>>, _, trace_messages) do
+    msg_id = raw_msg_id - @protobuf_offset
+
+    with {:ok, type} <- Map.fetch(@ids_to_message_type, msg_id),
          {:ok, type} <- validate_implemented(type),
-         {:ok, msg} <- type.from_fields(Enum.slice(fields, 1..-1//1)) do
+         {:ok, msg} <- type.from_protobuf(payload) do
       if trace_messages do
         Logger.info(Traceable.to_s(msg))
       end
 
       {:ok, msg}
     else
-      {:error, {:not_implemented, _type}} ->
-        fields = Base.get_fields(str)
-        Logger.warning("<-- #{inspect(fields, limit: :infinity)}")
+      {:error, {:not_implemented, type}} ->
+        Logger.warning("<-- Not implemented: msg_id=#{msg_id} type=#{type}")
         {:error, :not_implemented}
 
       err ->
-        fields = Base.get_fields(str)
-        Logger.warning("Frame: #{inspect(str, limit: :infinity)}")
-        Logger.warning("Fields: #{inspect(fields, limit: :infinity)}")
+        Logger.warning(
+          "Protobuf frame: msg_id=#{msg_id} raw=#{raw_msg_id} payload=#{inspect(payload, limit: :infinity)}"
+        )
+
         Logger.error("Unexpected Error: #{inspect(err)}")
         {:error, :unexpected_error}
     end

--- a/lib/ib_ex/client/messages/start_api/request.ex
+++ b/lib/ib_ex/client/messages/start_api/request.ex
@@ -33,6 +33,20 @@ defmodule IbEx.Client.Messages.StartApi.Request do
     end
   end
 
+  def to_protobuf(%__MODULE__{} = msg) do
+    optional_caps =
+      case msg.optional_capabilities do
+        [caps] when is_binary(caps) -> caps
+        _ -> nil
+      end
+
+    %IbEx.Client.Proto.Protobuf.StartApiRequest{
+      client_id: msg.client_id,
+      optional_capabilities: optional_caps
+    }
+    |> Protobuf.encode()
+  end
+
   defimpl String.Chars, for: __MODULE__ do
     alias IbEx.Client.Messages.Base
 

--- a/test/ib_ex/client/messages/responses_test.exs
+++ b/test/ib_ex/client/messages/responses_test.exs
@@ -1,0 +1,103 @@
+defmodule IbEx.Client.Messages.ResponsesTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Messages.Responses
+
+  @protobuf_offset 200
+
+  describe "parse/3 with :connecting status" do
+    test "parses InitConnection response in legacy text format" do
+      str = "213\x0020240605 17:25:52 Central European Standard Time\x00"
+
+      assert {:ok, msg} = Responses.parse(str, :connecting, false)
+
+      assert %IbEx.Client.Messages.InitConnection.Response{} = msg
+      assert msg.server_version == 213
+      assert msg.connection_timestamp == ~N[2024-06-05 17:25:52]
+    end
+  end
+
+  describe "parse/3 with :connected status (protobuf)" do
+    test "extracts msg_id from 4-byte big-endian integer and subtracts 200" do
+      # ManagedAccounts has msg_id=15, wire_id=15+200=215
+      proto_payload =
+        %IbEx.Client.Proto.Protobuf.ManagedAccounts{accounts_list: "DU123456"}
+        |> Protobuf.encode()
+
+      wire_msg = <<15 + @protobuf_offset::big-integer-size(32), proto_payload::binary>>
+
+      assert {:ok, msg} = Responses.parse(wire_msg, :connected, false)
+
+      assert %IbEx.Client.Messages.Misc.ManagedAccounts{} = msg
+      assert msg.accounts == "DU123456"
+    end
+
+    test "parses NextValidId protobuf message" do
+      # NextValidId has msg_id=9, wire_id=9+200=209
+      proto_payload =
+        %IbEx.Client.Proto.Protobuf.NextValidId{order_id: 42}
+        |> Protobuf.encode()
+
+      wire_msg = <<9 + @protobuf_offset::big-integer-size(32), proto_payload::binary>>
+
+      assert {:ok, msg} = Responses.parse(wire_msg, :connected, false)
+
+      assert %IbEx.Client.Messages.Ids.NextValidId{} = msg
+      assert msg.next_valid_id == 42
+    end
+
+    test "parses ErrorMessage protobuf as Error when id != -1" do
+      proto_payload =
+        %IbEx.Client.Proto.Protobuf.ErrorMessage{
+          id: 1,
+          error_code: 200,
+          error_msg: "No security definition has been found"
+        }
+        |> Protobuf.encode()
+
+      wire_msg = <<4 + @protobuf_offset::big-integer-size(32), proto_payload::binary>>
+
+      assert {:ok, msg} = Responses.parse(wire_msg, :connected, false)
+
+      assert %IbEx.Client.Messages.ErrorInfo.Error{} = msg
+      assert msg.id == 1
+      assert msg.code == 200
+      assert msg.message == "No security definition has been found"
+    end
+
+    test "parses ErrorMessage protobuf as Info when id == -1" do
+      proto_payload =
+        %IbEx.Client.Proto.Protobuf.ErrorMessage{
+          id: -1,
+          error_code: 2104,
+          error_msg: "Market data farm connection is OK"
+        }
+        |> Protobuf.encode()
+
+      wire_msg = <<4 + @protobuf_offset::big-integer-size(32), proto_payload::binary>>
+
+      assert {:ok, msg} = Responses.parse(wire_msg, :connected, false)
+
+      assert %IbEx.Client.Messages.ErrorInfo.Info{} = msg
+      assert msg.id == -1
+      assert msg.code == 2104
+      assert msg.message == "Market data farm connection is OK"
+    end
+
+    @tag capture_log: true
+    test "returns :not_implemented for unimplemented message types" do
+      # msg_id=7 is "portfolio_value" (a string, not a module)
+      wire_msg = <<7 + @protobuf_offset::big-integer-size(32), "some_payload">>
+
+      assert {:error, :not_implemented} = Responses.parse(wire_msg, :connected, false)
+    end
+
+    @tag capture_log: true
+    test "returns :unexpected_error for unknown msg_ids" do
+      # msg_id=999 is not in the lookup table
+      wire_msg = <<999 + @protobuf_offset::big-integer-size(32), "some_payload">>
+
+      assert {:error, :unexpected_error} = Responses.parse(wire_msg, :connected, false)
+    end
+  end
+end

--- a/test/ib_ex/client/messages/start_api/request_test.exs
+++ b/test/ib_ex/client/messages/start_api/request_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Messages.StartApi.RequestTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Messages.StartApi.Request
+  alias IbEx.Client.Messages.Requests
   alias IbEx.Client.Protocols.Traceable
 
   describe "new/1" do
@@ -20,6 +21,43 @@ defmodule IbEx.Client.Messages.StartApi.RequestTest do
       {:ok, msg} = Request.new([])
 
       assert to_string(msg) == <<55, 49, 0, 50, 0, 48, 0>>
+    end
+  end
+
+  describe "to_protobuf/1" do
+    test "encodes the request to a protobuf binary that decodes to the correct fields" do
+      {:ok, msg} = Request.new(client_id: 1)
+
+      payload = Request.to_protobuf(msg)
+
+      decoded = IbEx.Client.Proto.Protobuf.StartApiRequest.decode(payload)
+      assert decoded.client_id == 1
+      assert decoded.optional_capabilities == nil
+    end
+
+    test "includes optional_capabilities when present" do
+      {:ok, msg} = Request.new(client_id: 0, optional_capabilities: "SOME_CAP")
+
+      payload = Request.to_protobuf(msg)
+
+      decoded = IbEx.Client.Proto.Protobuf.StartApiRequest.decode(payload)
+      assert decoded.client_id == 0
+      assert decoded.optional_capabilities == "SOME_CAP"
+    end
+  end
+
+  describe "encode_request/1" do
+    test "produces a binary with 4-byte wire_id header followed by protobuf payload" do
+      {:ok, msg} = Request.new(client_id: 0)
+
+      assert {:ok, encoded} = Requests.encode_request(msg)
+
+      # msg_id=71, wire_id=71+200=271
+      <<wire_id::big-integer-size(32), payload::binary>> = encoded
+      assert wire_id == 271
+
+      decoded = IbEx.Client.Proto.Protobuf.StartApiRequest.decode(payload)
+      assert decoded.client_id == 0
     end
   end
 

--- a/test/ib_ex/client_test.exs
+++ b/test/ib_ex/client_test.exs
@@ -31,8 +31,6 @@ defmodule IbEx.ClientTest do
 
   alias IbEx.Client
   alias IbEx.Client.Messages.MatchingSymbols.Request
-  alias IbEx.Client.Types.Contract
-  alias IbEx.Client.Types.ContractDescription
   alias IbEx.Client.Subscriptions
 
   alias __MODULE__.MockSuccessConnection
@@ -59,27 +57,28 @@ defmodule IbEx.ClientTest do
     test "updates the client's state with the server version, the connection timestamp and continues to validate the server version" do
       initial_state = %{status: :connecting, trace_messages: false}
 
-      str = "178\x0020240605 17:25:52 Central European Standard Time\x00"
+      str = "213\x0020240605 17:25:52 Central European Standard Time\x00"
 
       assert {:noreply, new_state, continuation} = Client.handle_cast({:process_message, str}, initial_state)
 
-      assert new_state.server_version == 178
+      assert new_state.server_version == 213
       assert new_state.connection_timestamp == ~N[2024-06-05 17:25:52]
       assert new_state.status == :connected
 
       assert continuation == {:continue, :validate_server_version}
     end
 
-    @symbol_samples_msg_str <<55, 57, 0, 49, 0, 49, 55, 0, 50, 54, 53, 53, 57, 56, 0, 65, 65, 80, 76, 0, 83, 84, 75, 0,
-                              78, 65, 83, 68, 65, 81, 0, 85, 83, 68, 0, 53, 0, 67, 70, 68, 0, 79, 80, 84, 0, 73, 79, 80,
-                              84, 0, 87, 65, 82, 0, 66, 65, 71, 0, 65, 80, 80, 76, 69, 32, 73, 78, 67, 0, 0, 52, 57, 51,
-                              53, 52, 54, 48, 52, 56, 0, 65, 65, 80, 76, 0, 83, 84, 75, 0, 76, 83, 69, 69, 84, 70, 0,
-                              71, 66, 80, 0, 48, 0, 76, 83, 32, 49, 88, 32, 65, 65, 80, 76, 0, 0>>
-
     @tag capture_log: true
     test "relays the msg when there's a subscription for said message" do
       table_ref = Subscriptions.initialize()
       Subscriptions.subscribe_by_request_id(table_ref, self())
+
+      # Build a protobuf ManagedAccounts message (msg_id=15, wire_id=215)
+      proto_payload =
+        %IbEx.Client.Proto.Protobuf.ManagedAccounts{accounts_list: "DU123456,DU789012"}
+        |> Protobuf.encode()
+
+      wire_msg = <<215::big-integer-size(32), proto_payload::binary>>
 
       state = %{
         subscriptions_table_ref: table_ref,
@@ -87,27 +86,24 @@ defmodule IbEx.ClientTest do
         trace_messages: false
       }
 
-      assert {:noreply, ^state} = Client.handle_cast({:process_message, @symbol_samples_msg_str}, state)
+      assert {:noreply, %{managed_accounts: "DU123456,DU789012"}} =
+               Client.handle_cast({:process_message, wire_msg}, state)
+    end
+  end
 
-      assert_received {:"$gen_cast", {:message_received, msg}}
+  describe "handle_continue(:validate_server_version)" do
+    test "continues to :request_start_api when server_version meets minimum (213)" do
+      state = %IbEx.Client{server_version: 213}
 
-      assert msg.request_id == "1"
-      assert length(msg.contracts) == 2
+      assert {:noreply, ^state, {:continue, :request_start_api}} =
+               Client.handle_continue(:validate_server_version, state)
+    end
 
-      first_contract = List.first(msg.contracts)
+    test "stops the process when server_version is below minimum (213)" do
+      state = %IbEx.Client{server_version: 178}
 
-      assert first_contract == %ContractDescription{
-               contract: %Contract{
-                 conid: "265598",
-                 symbol: "AAPL",
-                 security_type: "STK",
-                 currency: "USD",
-                 primary_exchange: "NASDAQ",
-                 description: "APPLE INC",
-                 issuer_id: ""
-               },
-               derivative_security_types: ["CFD", "OPT", "IOPT", "WAR", "BAG"]
-             }
+      assert {:stop, {:required_version_unmet, :protobuf_rest_messages_3, 178}} =
+               Client.handle_continue(:validate_server_version, state)
     end
   end
 


### PR DESCRIPTION
## Summary

- Bump minimum server version to 213 (`protobuf_support`)
- Change `Responses.parse` to read 4-byte big-endian msg_id (offset 200) and dispatch to `from_protobuf/1`
- Add `Requests.encode_request/1` to prepend wire header before protobuf payload
- Update `Connection.send_message` to accept pre-encoded binary
- Add `from_protobuf/1` to ManagedAccounts, NextValidId, ErrorInfo.Base
- Add `to_protobuf/1` to StartApi.Request, MatchingSymbols.Request
- InitConnection handshake remains legacy text-based

## Test plan

- [x] Responses protobuf dispatch tests (7 tests)
- [x] StartApi.Request to_protobuf/1 and encode_request/1 tests
- [x] Client integration test updated for protobuf flow
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] 445 tests, 0 failures