### PR TITLE
Add Client.subscribe/3 and Client.unsubscribe/2 for stream subscriptions

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -61,6 +61,14 @@ defmodule IbEx.Client do
     GenServer.call(pid, {:request, proto_msg, opts}, timeout)
   end
 
+  def subscribe(pid, proto_msg, opts \\ []) do
+    GenServer.call(pid, {:subscribe, self(), proto_msg, opts})
+  end
+
+  def unsubscribe(pid, subscription_ref) do
+    GenServer.call(pid, {:unsubscribe, subscription_ref})
+  end
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts)
   end
@@ -170,6 +178,36 @@ defmodule IbEx.Client do
     end
   end
 
+  def handle_call({:subscribe, subscriber, %message_type{} = proto_msg, _opts}, _from, state) do
+    table_ref = state.subscriptions_table_ref
+
+    with {:ok, %{type: :stream}} <- Conversations.conversation_for(message_type) do
+      req_id = Subscriptions.allocate_request_id(table_ref)
+      subscription_ref = make_ref()
+      monitor_ref = Process.monitor(subscriber)
+
+      Subscriptions.register_stream(table_ref, req_id, subscriber, monitor_ref, subscription_ref, message_type)
+      send_to_tws(state, %{proto_msg | req_id: req_id})
+
+      {:reply, {:ok, subscription_ref}, state}
+    else
+      _ -> {:reply, {:error, :unknown_conversation}, state}
+    end
+  end
+
+  def handle_call({:unsubscribe, subscription_ref}, _from, state) do
+    table_ref = state.subscriptions_table_ref
+
+    case Subscriptions.lookup_by_subscription_ref(table_ref, subscription_ref) do
+      {:ok, key, entry} ->
+        cancel_stream(state, table_ref, key, entry)
+        {:reply, :ok, state}
+
+      {:error, :missing_subscription} ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
   def handle_info({:request_timeout, key}, state) do
     table_ref = state.subscriptions_table_ref
 
@@ -179,6 +217,20 @@ defmodule IbEx.Client do
         Subscriptions.remove_subscription(table_ref, key)
 
       _ ->
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, monitor_ref, :process, _pid, _reason}, state) do
+    table_ref = state.subscriptions_table_ref
+
+    case Subscriptions.lookup_by_monitor_ref(table_ref, monitor_ref) do
+      {:ok, key, entry} ->
+        cancel_stream(state, table_ref, key, entry)
+
+      {:error, :missing_subscription} ->
         :ok
     end
 
@@ -220,12 +272,30 @@ defmodule IbEx.Client do
     end
   end
 
+  defp cancel_stream(state, table_ref, key, %{monitor_ref: monitor_ref, request_module: request_module}) do
+    Process.demonitor(monitor_ref, [:flush])
+
+    case Conversations.cancel_request_for(request_module) do
+      {:ok, cancel_module} ->
+        req_id = String.to_integer(key)
+        send_to_tws(state, struct!(cancel_module, req_id: req_id))
+
+      :error ->
+        :ok
+    end
+
+    Subscriptions.remove_subscription(table_ref, key)
+  end
+
   defp dispatch_message(%Types.Error{id: id} = error, table_ref) when id > 0 do
     key = to_string(id)
 
     case Subscriptions.lookup(table_ref, key) do
       {:ok, %{type: :request} = entry} ->
         complete_conversation(table_ref, key, entry, {:error, error})
+
+      {:ok, %{type: :stream, subscriber: subscriber, subscription_ref: ref}} ->
+        send(subscriber, {:ib_ex, ref, {:error, error}})
 
       _ ->
         :ok
@@ -245,6 +315,9 @@ defmodule IbEx.Client do
     case Subscriptions.lookup(table_ref, key) do
       {:ok, %{type: :request} = entry} ->
         handle_conversation_response(table_ref, key, msg, module, entry)
+
+      {:ok, %{type: :stream, subscriber: subscriber, subscription_ref: ref}} ->
+        send(subscriber, {:ib_ex, ref, msg})
 
       _ ->
         :ok

--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -23,6 +23,12 @@ defmodule IbEx.Client.Conversations do
       type: :request_response,
       correlation: :req_id,
       responses: [Proto.SymbolSamples]
+    },
+    Proto.MarketDataRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.TickPrice, Proto.TickSize],
+      cancel_request: Proto.CancelMarketData
     }
   }
 

--- a/lib/ib_ex/client/subscriptions.ex
+++ b/lib/ib_ex/client/subscriptions.ex
@@ -192,6 +192,32 @@ defmodule IbEx.Client.Subscriptions do
     end
   end
 
+  @doc """
+  Looks up a stream subscription entry by its monitor reference.
+
+  Returns `{:ok, key, entry}` on success or `{:error, :missing_subscription}` if no
+  entry matches.
+  """
+  def lookup_by_monitor_ref(table_ref, monitor_ref) do
+    result =
+      :ets.foldl(
+        fn
+          {key, %{type: :stream, monitor_ref: ^monitor_ref} = entry}, _acc ->
+            {:found, key, entry}
+
+          _other, acc ->
+            acc
+        end,
+        :not_found,
+        table_ref
+      )
+
+    case result do
+      {:found, key, entry} -> {:ok, key, entry}
+      :not_found -> {:error, :missing_subscription}
+    end
+  end
+
   def reverse_lookup(table_ref, pid) do
     spec = {List.to_atom(~c"$1"), pid}
 

--- a/test/ib_ex/client_test.exs
+++ b/test/ib_ex/client_test.exs
@@ -29,6 +29,30 @@ defmodule IbEx.ClientTest do
     end
   end
 
+  defmodule MockRecordingConnection do
+    use GenServer
+
+    def start_link(opts) do
+      test_pid = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{test_pid: test_pid})
+    end
+
+    @impl true
+    def init(state) do
+      {:ok, state}
+    end
+
+    def send_message(pid, msg) do
+      GenServer.call(pid, {:send_message, msg})
+    end
+
+    @impl true
+    def handle_call({:send_message, msg}, _from, state) do
+      send(state.test_pid, {:tws_sent, msg})
+      {:reply, :ok, state}
+    end
+  end
+
   alias IbEx.Client
   alias IbEx.Client.Subscriptions
 
@@ -238,6 +262,248 @@ defmodule IbEx.ClientTest do
 
       # No ETS entry for key "999" -- already completed
       assert {:noreply, ^state} = Client.handle_info({:request_timeout, "999"}, state)
+    end
+  end
+
+  describe "subscribe/3" do
+    test "returns {:ok, subscription_ref} and registers a stream entry in ETS" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      table_ref = state.subscriptions_table_ref
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      assert {:reply, {:ok, subscription_ref}, ^state} =
+               Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      assert is_reference(subscription_ref)
+
+      # Verify ETS entry was created as a :stream type with req_id "1"
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, "1")
+      assert entry.type == :stream
+      assert entry.subscriber == self()
+      assert entry.subscription_ref == subscription_ref
+      assert entry.request_module == IbEx.Client.Proto.Protobuf.MarketDataRequest
+      assert is_reference(entry.monitor_ref)
+    end
+
+    test "returns {:error, :unknown_conversation} for non-stream conversation types" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      # MatchingSymbolsRequest is :request_response, not :stream
+      proto_msg = %IbEx.Client.Proto.Protobuf.MatchingSymbolsRequest{pattern: "AAPL"}
+
+      assert {:reply, {:error, :unknown_conversation}, ^state} =
+               Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+    end
+  end
+
+  describe "stream message delivery" do
+    test "delivers TickPrice messages as {:ib_ex, ref, msg} via send/2" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, subscription_ref}, ^state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # Simulate receiving a TickPrice response with req_id=1 (msg_id=1, wire_id=201)
+      tick_price = %IbEx.Client.Proto.Protobuf.TickPrice{req_id: 1, tick_type: 4, price: 150.25}
+      wire_msg = <<201::big-integer-size(32), Protobuf.encode(tick_price)::binary>>
+
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_msg}, state)
+
+      assert_receive {:ib_ex, ^subscription_ref,
+                      %IbEx.Client.Proto.Protobuf.TickPrice{req_id: 1, tick_type: 4, price: 150.25}}
+    end
+
+    test "delivers multiple messages continuously without consuming the subscription" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      table_ref = state.subscriptions_table_ref
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, subscription_ref}, ^state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # Send first tick
+      tick_1 = %IbEx.Client.Proto.Protobuf.TickPrice{req_id: 1, tick_type: 4, price: 150.25}
+      wire_1 = <<201::big-integer-size(32), Protobuf.encode(tick_1)::binary>>
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_1}, state)
+
+      assert_receive {:ib_ex, ^subscription_ref, %IbEx.Client.Proto.Protobuf.TickPrice{price: 150.25}}
+
+      # Send second tick -- subscription should still be active
+      tick_2 = %IbEx.Client.Proto.Protobuf.TickPrice{req_id: 1, tick_type: 4, price: 151.00}
+      wire_2 = <<201::big-integer-size(32), Protobuf.encode(tick_2)::binary>>
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_2}, state)
+
+      assert_receive {:ib_ex, ^subscription_ref, %IbEx.Client.Proto.Protobuf.TickPrice{price: 151.00}}
+
+      # ETS entry should still exist
+      assert {:ok, %{type: :stream}} = Subscriptions.lookup(table_ref, "1")
+    end
+
+    test "delivers error messages to stream subscribers" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, subscription_ref}, ^state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # Simulate receiving an ErrorMessage with id=1 (msg_id=4, wire_id=204)
+      error_proto = %IbEx.Client.Proto.Protobuf.ErrorMessage{
+        id: 1,
+        error_code: 354,
+        error_msg: "Requested market data is not subscribed."
+      }
+
+      wire_msg = <<204::big-integer-size(32), Protobuf.encode(error_proto)::binary>>
+
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_msg}, state)
+
+      assert_receive {:ib_ex, ^subscription_ref,
+                      {:error,
+                       %IbEx.Client.Types.Error{id: 1, code: 354, message: "Requested market data is not subscribed."}}}
+    end
+  end
+
+  describe "unsubscribe/2" do
+    test "sends CancelMarketData to TWS, demonitors, and cleans up ETS" do
+      {:ok, state} = Client.init(connection_handler: MockRecordingConnection)
+      table_ref = state.subscriptions_table_ref
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, subscription_ref}, ^state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # Drain the subscribe request that was sent to TWS
+      assert_receive {:tws_sent, _subscribe_msg}
+
+      # Verify ETS entry exists
+      assert {:ok, %{type: :stream, monitor_ref: monitor_ref}} = Subscriptions.lookup(table_ref, "1")
+
+      # Unsubscribe
+      assert {:reply, :ok, ^state} =
+               Client.handle_call({:unsubscribe, subscription_ref}, {self(), make_ref()}, state)
+
+      # Verify CancelMarketData was sent to TWS
+      assert_receive {:tws_sent, cancel_msg}
+
+      # Decode the cancel message: 4-byte wire_id header + protobuf payload
+      <<wire_id::big-integer-size(32), payload::binary>> = cancel_msg
+      # CancelMarketData msg_id=2, wire_id=202
+      assert wire_id == 202
+      decoded = Protobuf.decode(payload, IbEx.Client.Proto.Protobuf.CancelMarketData)
+      assert decoded.req_id == 1
+
+      # ETS entry should be cleaned up
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+
+      # Monitor should have been removed (verify by checking it's not a valid monitor)
+      refute Process.read_timer(monitor_ref)
+    end
+
+    test "returns {:error, :not_found} for unknown subscription ref" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      unknown_ref = make_ref()
+
+      assert {:reply, {:error, :not_found}, ^state} =
+               Client.handle_call({:unsubscribe, unknown_ref}, {self(), make_ref()}, state)
+    end
+
+    test "stops message delivery after unsubscribe" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, subscription_ref}, ^state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # Unsubscribe
+      assert {:reply, :ok, ^state} =
+               Client.handle_call({:unsubscribe, subscription_ref}, {self(), make_ref()}, state)
+
+      # Simulate receiving a TickPrice -- should not be delivered
+      tick = %IbEx.Client.Proto.Protobuf.TickPrice{req_id: 1, tick_type: 4, price: 150.25}
+      wire_msg = <<201::big-integer-size(32), Protobuf.encode(tick)::binary>>
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_msg}, state)
+
+      refute_receive {:ib_ex, _, _}
+    end
+  end
+
+  describe "subscriber death cleanup" do
+    test "handle_info(:DOWN) sends cancel to TWS and cleans up ETS when subscriber dies" do
+      {:ok, state} = Client.init(connection_handler: MockRecordingConnection)
+      table_ref = state.subscriptions_table_ref
+
+      # Spawn a subscriber process that we can kill
+      subscriber = spawn(fn -> Process.sleep(:infinity) end)
+      # Monitor it from test process so we can confirm death
+      test_monitor = Process.monitor(subscriber)
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, _subscription_ref}, ^state} =
+        Client.handle_call({:subscribe, subscriber, proto_msg, []}, {self(), make_ref()}, state)
+
+      # Drain the subscribe request sent to TWS
+      assert_receive {:tws_sent, _subscribe_msg}
+
+      # Verify ETS entry exists and grab the monitor ref
+      assert {:ok, %{type: :stream, monitor_ref: monitor_ref}} = Subscriptions.lookup(table_ref, "1")
+
+      # Kill the subscriber and wait for confirmation
+      Process.exit(subscriber, :kill)
+      assert_receive {:DOWN, ^test_monitor, :process, ^subscriber, :killed}
+
+      # The handle_call(:subscribe) also set up a monitor, so flush that :DOWN from our mailbox
+      # (since handle_call runs in test process context, that monitor fires here too)
+      receive do
+        {:DOWN, ^monitor_ref, :process, ^subscriber, :killed} -> :ok
+      after
+        100 -> :ok
+      end
+
+      # Simulate the :DOWN message that the Client GenServer would receive
+      assert {:noreply, ^state} =
+               Client.handle_info({:DOWN, monitor_ref, :process, subscriber, :killed}, state)
+
+      # Verify CancelMarketData was sent to TWS
+      assert_receive {:tws_sent, cancel_msg}
+      <<wire_id::big-integer-size(32), payload::binary>> = cancel_msg
+      assert wire_id == 202
+      decoded = Protobuf.decode(payload, IbEx.Client.Proto.Protobuf.CancelMarketData)
+      assert decoded.req_id == 1
+
+      # ETS entry should be cleaned up
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+    end
+
+    test "handle_info(:DOWN) is a no-op for unknown monitor refs" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      unknown_monitor = make_ref()
+
+      assert {:noreply, ^state} =
+               Client.handle_info({:DOWN, unknown_monitor, :process, self(), :normal}, state)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `Client.subscribe/3` — allocates req_id internally, returns opaque `subscription_ref`, monitors subscriber, registers stream in ETS, sends proto to TWS
- Adds `Client.unsubscribe/2` — looks up by subscription_ref, sends cancel proto to TWS, demonitors, cleans up ETS
- Adds `handle_info({:DOWN, ...})` for automatic cancel + cleanup on subscriber death
- Extends `dispatch_message` to deliver stream messages via `send(pid, {:ib_ex, ref, msg})`
- Adds `:stream` conversation type for `MarketDataRequest` → `TickPrice`/`TickSize` + `CancelMarketData`
- Adds `Subscriptions.lookup_by_monitor_ref/2` for the `:DOWN` handler

## Test plan
- [x] subscribe/3 returns `{:ok, ref}` and registers `:stream` entry in ETS
- [x] Rejects non-stream conversation types with `{:error, :unknown_conversation}`
- [x] TickPrice messages delivered as `{:ib_ex, ref, msg}` via send/2
- [x] Multiple messages delivered continuously without consuming the subscription
- [x] Error messages delivered to stream subscribers
- [x] unsubscribe/2 sends CancelMarketData to TWS, demonitors, cleans ETS
- [x] Returns `{:error, :not_found}` for unknown subscription refs
- [x] Message delivery stops after unsubscribe
- [x] Subscriber death triggers automatic CancelMarketData + ETS cleanup
- [x] Unknown monitor refs are a no-op