### PR TITLE
Populate full conversations registry with global correlation support

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -169,29 +169,28 @@ defmodule IbEx.Client do
   def handle_call({:request, %message_type{} = proto_msg, opts}, from, state) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
 
-    with {:ok, _shape} <- Conversations.conversation_for(message_type),
-         {:ok, req_id} <- register_conversation(state.subscriptions_table_ref, from, timeout, message_type) do
-      send_to_tws(state, %{proto_msg | req_id: req_id})
-      {:noreply, state}
-    else
-      :error -> {:reply, {:error, :unknown_conversation}, state}
+    case Conversations.register_request(state.subscriptions_table_ref, message_type, from, timeout, self()) do
+      {:ok, _key, req_id} when is_integer(req_id) ->
+        send_to_tws(state, %{proto_msg | req_id: req_id})
+        {:noreply, state}
+
+      {:ok, _key, nil} ->
+        send_to_tws(state, proto_msg)
+        {:noreply, state}
+
+      :error ->
+        {:reply, {:error, :unknown_conversation}, state}
     end
   end
 
   def handle_call({:subscribe, subscriber, %message_type{} = proto_msg, _opts}, _from, state) do
-    table_ref = state.subscriptions_table_ref
+    case Conversations.register_stream(state.subscriptions_table_ref, message_type, subscriber) do
+      {:ok, req_id, subscription_ref} ->
+        send_to_tws(state, %{proto_msg | req_id: req_id})
+        {:reply, {:ok, subscription_ref}, state}
 
-    with {:ok, %{type: :stream}} <- Conversations.conversation_for(message_type) do
-      req_id = Subscriptions.allocate_request_id(table_ref)
-      subscription_ref = make_ref()
-      monitor_ref = Process.monitor(subscriber)
-
-      Subscriptions.register_stream(table_ref, req_id, subscriber, monitor_ref, subscription_ref, message_type)
-      send_to_tws(state, %{proto_msg | req_id: req_id})
-
-      {:reply, {:ok, subscription_ref}, state}
-    else
-      _ -> {:reply, {:error, :unknown_conversation}, state}
+      :error ->
+        {:reply, {:error, :unknown_conversation}, state}
     end
   end
 
@@ -257,14 +256,6 @@ defmodule IbEx.Client do
     end
   end
 
-  defp register_conversation(table_ref, from, timeout, request_module) do
-    req_id = Subscriptions.allocate_request_id(table_ref)
-    key = to_string(req_id)
-    timer_ref = Process.send_after(self(), {:request_timeout, key}, timeout)
-    Subscriptions.register_request(table_ref, req_id, from, timer_ref, request_module)
-    {:ok, req_id}
-  end
-
   defp send_to_tws(state, msg) do
     case Messages.Requests.encode_request(msg) do
       {:ok, encoded} -> Connection.send_message(state.connection, encoded)
@@ -277,7 +268,7 @@ defmodule IbEx.Client do
 
     case Conversations.cancel_request_for(request_module) do
       {:ok, cancel_module} ->
-        req_id = String.to_integer(key)
+        {:request_id, req_id} = key
         send_to_tws(state, struct!(cancel_module, req_id: req_id))
 
       :error ->
@@ -288,7 +279,7 @@ defmodule IbEx.Client do
   end
 
   defp dispatch_message(%Types.Error{id: id} = error, table_ref) when id > 0 do
-    key = to_string(id)
+    key = {:request_id, id}
 
     case Subscriptions.lookup(table_ref, key) do
       {:ok, %{type: :request} = entry} ->
@@ -305,7 +296,7 @@ defmodule IbEx.Client do
   defp dispatch_message(%module{} = msg, table_ref) do
     case Map.get(msg, :req_id) do
       nil -> dispatch_by_module(module, msg, table_ref)
-      req_id -> dispatch_by_req_id(to_string(req_id), msg, module, table_ref)
+      req_id -> dispatch_by_req_id({:request_id, req_id}, msg, module, table_ref)
     end
   end
 
@@ -348,12 +339,31 @@ defmodule IbEx.Client do
   end
 
   defp dispatch_by_module(module, msg, table_ref) do
-    case Subscriptions.lookup(table_ref, module) do
-      {:ok, pid} when is_pid(pid) ->
-        GenServer.cast(pid, {:message_received, msg})
+    case find_global_conversation(module, table_ref) do
+      {:ok, key, entry} ->
+        handle_conversation_response(table_ref, key, msg, module, entry)
 
-      _ ->
-        :ok
+      :not_found ->
+        case Subscriptions.lookup(table_ref, module) do
+          {:ok, pid} when is_pid(pid) ->
+            GenServer.cast(pid, {:message_received, msg})
+
+          _ ->
+            :ok
+        end
     end
+  end
+
+  defp find_global_conversation(response_module, table_ref) do
+    request_modules = Conversations.requests_for_response(response_module)
+
+    Enum.find_value(request_modules, :not_found, fn request_module ->
+      key = {:global, request_module}
+
+      case Subscriptions.lookup(table_ref, key) do
+        {:ok, %{type: :request} = entry} -> {:ok, key, entry}
+        _ -> nil
+      end
+    end)
   end
 end

--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -7,11 +7,114 @@ defmodule IbEx.Client.Conversations do
   and cancel request module.
 
   Provides compile-time derived indexes for efficient lookup.
+
+  ## Conversation Types
+
+  * `:request_response` -- single request, single response
+  * `:bounded_stream` -- single request, multiple responses terminated by an end marker
+  * `:stream` -- long-lived subscription producing continuous responses, cancelled explicitly
+  * `:command` -- fire-and-forget request with no expected response
+
+  ## Correlation Methods
+
+  * `:req_id` -- response carries a `req_id` field matching the request
+  * `:order_id` -- response carries an order ID field (e.g. PlaceOrder lifecycle)
+  * `:global` -- response carries no `req_id`; ETS key is `{:global, request_module}`
   """
 
   alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Subscriptions
 
   @conversations %{
+    # -----------------------------------------------------------------------
+    # Single request/response types (correlation: :req_id)
+    # -----------------------------------------------------------------------
+    Proto.HeadTimestampRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.HeadTimestamp]
+    },
+    Proto.HistogramDataRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.HistogramData]
+    },
+    Proto.FundamentalsDataRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.FundamentalsData]
+    },
+    Proto.NewsArticleRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.NewsArticle]
+    },
+    Proto.SoftDollarTiersRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.SoftDollarTiers]
+    },
+    Proto.SmartComponentsRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.SmartComponents]
+    },
+    Proto.UserInfoRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.UserInfo]
+    },
+    Proto.ConfigRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.ConfigResponse]
+    },
+    Proto.MatchingSymbolsRequest => %{
+      type: :request_response,
+      correlation: :req_id,
+      responses: [Proto.SymbolSamples]
+    },
+
+    # Single request/response types (correlation: :global -- no req_id)
+    Proto.CurrentTimeRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.CurrentTime]
+    },
+    Proto.CurrentTimeInMillisRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.CurrentTimeInMillis]
+    },
+    Proto.ScannerParametersRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.ScannerParameters]
+    },
+    Proto.NewsProvidersRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.NewsProviders]
+    },
+    Proto.FamilyCodesRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.FamilyCodes]
+    },
+    Proto.MarketDepthExchangesRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.MarketDepthExchanges]
+    },
+    Proto.MarketRuleRequest => %{
+      type: :request_response,
+      correlation: :global,
+      responses: [Proto.MarketRule]
+    },
+
+    # -----------------------------------------------------------------------
+    # Bounded stream types (correlation: :req_id, with end markers)
+    # -----------------------------------------------------------------------
     Proto.ContractDataRequest => %{
       type: :bounded_stream,
       correlation: :req_id,
@@ -19,18 +122,293 @@ defmodule IbEx.Client.Conversations do
       end_marker: Proto.ContractDataEnd,
       cancel_request: Proto.CancelContractData
     },
-    Proto.MatchingSymbolsRequest => %{
-      type: :request_response,
+    Proto.ExecutionRequest => %{
+      type: :bounded_stream,
       correlation: :req_id,
-      responses: [Proto.SymbolSamples]
+      responses: [Proto.ExecutionDetails],
+      end_marker: Proto.ExecutionDetailsEnd
     },
+    Proto.HistoricalDataRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.HistoricalData, Proto.HistoricalDataUpdate, Proto.HistoricalSchedule],
+      end_marker: Proto.HistoricalDataEnd,
+      cancel_request: Proto.CancelHistoricalData
+    },
+    Proto.ScannerSubscriptionRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.ScannerData],
+      end_marker: nil,
+      cancel_request: Proto.CancelScannerSubscription
+    },
+    Proto.AccountSummaryRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.AccountSummary],
+      end_marker: Proto.AccountSummaryEnd,
+      cancel_request: Proto.CancelAccountSummary
+    },
+    Proto.PositionsMultiRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.PositionMulti],
+      end_marker: Proto.PositionMultiEnd,
+      cancel_request: Proto.CancelPositionsMulti
+    },
+    Proto.AccountUpdatesMultiRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.AccountUpdateMulti],
+      end_marker: Proto.AccountUpdateMultiEnd,
+      cancel_request: Proto.CancelAccountUpdatesMulti
+    },
+    Proto.SecDefOptParamsRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.SecDefOptParameter],
+      end_marker: Proto.SecDefOptParameterEnd
+    },
+    Proto.HistoricalNewsRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.HistoricalNews],
+      end_marker: Proto.HistoricalNewsEnd
+    },
+    Proto.HistoricalTicksRequest => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [Proto.HistoricalTicks, Proto.HistoricalTicksBidAsk, Proto.HistoricalTicksLast],
+      end_marker: nil,
+      cancel_request: Proto.CancelHistoricalTicks
+    },
+    Proto.FAReplace => %{
+      type: :bounded_stream,
+      correlation: :req_id,
+      responses: [],
+      end_marker: Proto.ReplaceFAEnd
+    },
+
+    # Bounded stream types (correlation: :global -- no req_id)
+    Proto.OpenOrdersRequest => %{
+      type: :bounded_stream,
+      correlation: :global,
+      responses: [Proto.OpenOrder],
+      end_marker: Proto.OpenOrdersEnd
+    },
+    Proto.AllOpenOrdersRequest => %{
+      type: :bounded_stream,
+      correlation: :global,
+      responses: [Proto.OpenOrder],
+      end_marker: Proto.OpenOrdersEnd
+    },
+    Proto.AccountDataRequest => %{
+      type: :bounded_stream,
+      correlation: :global,
+      responses: [Proto.AccountValue, Proto.PortfolioValue, Proto.AccountUpdateTime],
+      end_marker: Proto.AccountDataEnd
+    },
+    Proto.PositionsRequest => %{
+      type: :bounded_stream,
+      correlation: :global,
+      responses: [Proto.Position],
+      end_marker: Proto.PositionEnd,
+      cancel_request: Proto.CancelPositions
+    },
+    Proto.CompletedOrdersRequest => %{
+      type: :bounded_stream,
+      correlation: :global,
+      responses: [Proto.CompletedOrder],
+      end_marker: Proto.CompletedOrdersEnd
+    },
+
+    # -----------------------------------------------------------------------
+    # Continuous stream types (correlation: :req_id)
+    # -----------------------------------------------------------------------
     Proto.MarketDataRequest => %{
       type: :stream,
       correlation: :req_id,
-      responses: [Proto.TickPrice, Proto.TickSize],
+      responses: [
+        Proto.TickPrice,
+        Proto.TickSize,
+        Proto.TickGeneric,
+        Proto.TickString,
+        Proto.TickOptionComputation,
+        Proto.TickReqParams,
+        Proto.TickSnapshotEnd,
+        Proto.TickNews,
+        Proto.RerouteMarketDataRequest
+      ],
       cancel_request: Proto.CancelMarketData
+    },
+    Proto.RealTimeBarsRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.RealTimeBarTick],
+      cancel_request: Proto.CancelRealTimeBars
+    },
+    Proto.MarketDepthRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.MarketDepth, Proto.MarketDepthL2, Proto.RerouteMarketDepthRequest],
+      cancel_request: Proto.CancelMarketDepth
+    },
+    Proto.TickByTickRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.TickByTickData],
+      cancel_request: Proto.CancelTickByTick
+    },
+    Proto.CalculateImpliedVolatilityRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.TickOptionComputation],
+      cancel_request: Proto.CancelCalculateImpliedVolatility
+    },
+    Proto.CalculateOptionPriceRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.TickOptionComputation],
+      cancel_request: Proto.CancelCalculateOptionPrice
+    },
+    Proto.PnLRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.PnL],
+      cancel_request: Proto.CancelPnL
+    },
+    Proto.PnLSingleRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.PnLSingle],
+      cancel_request: Proto.CancelPnLSingle
+    },
+    Proto.WshMetaDataRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.WshMetaData],
+      cancel_request: Proto.CancelWshMetaData
+    },
+    Proto.WshEventDataRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.WshEventData],
+      cancel_request: Proto.CancelWshEventData
+    },
+
+    # Continuous stream types (correlation: :global -- no req_id)
+    Proto.NewsBulletinsRequest => %{
+      type: :stream,
+      correlation: :global,
+      responses: [Proto.NewsBulletin],
+      cancel_request: Proto.CancelNewsBulletins
+    },
+
+    # -----------------------------------------------------------------------
+    # Order lifecycle stream (correlation: :order_id)
+    # -----------------------------------------------------------------------
+    Proto.PlaceOrderRequest => %{
+      type: :stream,
+      correlation: :order_id,
+      responses: [
+        Proto.OpenOrder,
+        Proto.OrderStatus,
+        Proto.OrderBound,
+        Proto.CommissionAndFeesReport,
+        Proto.DeltaNeutralContract
+      ],
+      cancel_request: Proto.CancelOrderRequest
+    },
+
+    # -----------------------------------------------------------------------
+    # Command types (fire-and-forget, no direct response)
+    # Some commands (CancelOrder, GlobalCancel, ExerciseOptions) trigger
+    # responses (e.g. OrderStatus) that route through the order's PlaceOrder
+    # lifecycle stream rather than through a separate conversation.
+    # -----------------------------------------------------------------------
+    Proto.CancelOrderRequest => %{
+      type: :command,
+      correlation: :order_id,
+      responses: []
+    },
+    Proto.GlobalCancelRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: []
+    },
+    Proto.ExerciseOptionsRequest => %{
+      type: :command,
+      correlation: :req_id,
+      responses: []
+    },
+    Proto.MarketDataTypeRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.MarketDataType]
+    },
+    Proto.SetServerLogLevelRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: []
+    },
+    Proto.AutoOpenOrdersRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: []
+    },
+    Proto.FARequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.ReceiveFA]
+    },
+    Proto.IdsRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.NextValidId]
+    },
+    Proto.VerifyRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.VerifyMessageApi]
+    },
+    Proto.VerifyMessageRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.VerifyCompleted]
+    },
+    Proto.QueryDisplayGroupsRequest => %{
+      type: :command,
+      correlation: :req_id,
+      responses: [Proto.DisplayGroupList]
+    },
+    Proto.SubscribeToGroupEventsRequest => %{
+      type: :stream,
+      correlation: :req_id,
+      responses: [Proto.DisplayGroupUpdated],
+      cancel_request: Proto.UnsubscribeFromGroupEventsRequest
+    },
+    Proto.UpdateDisplayGroupRequest => %{
+      type: :command,
+      correlation: :req_id,
+      responses: []
+    },
+    Proto.ManagedAccountsRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.ManagedAccounts]
+    },
+    Proto.StartApiRequest => %{
+      type: :command,
+      correlation: :global,
+      responses: [Proto.ManagedAccounts, Proto.NextValidId]
     }
   }
+
+  @doc """
+  Returns all request modules that have a registered conversation.
+  """
+  @spec request_modules() :: [module()]
+  def request_modules, do: Map.keys(@conversations)
 
   @doc """
   Returns the conversation shape for the given request module.
@@ -92,6 +470,90 @@ defmodule IbEx.Client.Conversations do
   @spec requests_for_response(module()) :: [module()]
   def requests_for_response(response_module) do
     Map.get(response_to_requests(), response_module, [])
+  end
+
+  @doc """
+  Returns true if the given request module uses global correlation (no req_id).
+  """
+  @spec global_correlation?(module()) :: boolean()
+  def global_correlation?(request_module) do
+    case Map.fetch(@conversations, request_module) do
+      {:ok, %{correlation: :global}} -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Registers a conversation in ETS based on the request module's correlation type.
+
+  Looks up the conversation shape, determines the ETS key, allocates a req_id
+  if needed, registers the entry via Subscriptions, and sets up a timeout timer.
+
+  Returns `{:ok, key, req_id_or_nil}` on success or `:error` if the request
+  module has no registered conversation.
+
+  ## Parameters
+
+    * `table_ref` -- the ETS table reference
+    * `request_module` -- the proto request module (e.g. `Proto.ContractDataRequest`)
+    * `from` -- the GenServer `from` reference for replying later
+    * `timeout` -- timeout in milliseconds for the request timer
+    * `client_pid` -- the Client pid to send the timeout message to
+
+  """
+  @spec register_request(reference(), module(), GenServer.from(), non_neg_integer(), pid()) ::
+          {:ok, tuple(), non_neg_integer() | nil} | :error
+  def register_request(table_ref, request_module, from, timeout, client_pid) do
+    case conversation_for(request_module) do
+      {:ok, shape} ->
+        {key, req_id} = build_key(shape.correlation, table_ref, request_module)
+        timer_ref = Process.send_after(client_pid, {:request_timeout, key}, timeout)
+        Subscriptions.register_request(table_ref, key, from, timer_ref, request_module)
+        {:ok, key, req_id}
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc """
+  Registers a stream subscription in ETS for the given request module.
+
+  Validates the conversation is a `:stream` type, allocates a req_id,
+  monitors the subscriber process, and registers the stream entry via Subscriptions.
+
+  Returns `{:ok, req_id, subscription_ref}` on success or `:error` if the
+  request module is not a registered stream conversation.
+  """
+  @spec register_stream(reference(), module(), pid()) :: {:ok, non_neg_integer(), reference()} | :error
+  def register_stream(table_ref, request_module, subscriber) do
+    case conversation_for(request_module) do
+      {:ok, %{type: :stream}} ->
+        req_id = Subscriptions.allocate_request_id(table_ref)
+        key = {:request_id, req_id}
+        subscription_ref = make_ref()
+        monitor_ref = Process.monitor(subscriber)
+
+        Subscriptions.register_stream(table_ref, key, subscriber, monitor_ref, subscription_ref, request_module)
+        {:ok, req_id, subscription_ref}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp build_key(:req_id, table_ref, _request_module) do
+    req_id = Subscriptions.allocate_request_id(table_ref)
+    {{:request_id, req_id}, req_id}
+  end
+
+  defp build_key(:global, _table_ref, request_module) do
+    {{:global, request_module}, nil}
+  end
+
+  defp build_key(:order_id, table_ref, _request_module) do
+    order_id = Subscriptions.allocate_request_id(table_ref)
+    {{:order_id, order_id}, order_id}
   end
 
   defp end_markers do

--- a/lib/ib_ex/client/messages/requests.ex
+++ b/lib/ib_ex/client/messages/requests.ex
@@ -96,6 +96,12 @@ defmodule IbEx.Client.Messages.Requests do
     Map.fetch(@message_ids, atom)
   end
 
+  @doc """
+  Returns all request proto modules registered in the message_ids map.
+  """
+  @spec request_modules() :: [module()]
+  def request_modules, do: Map.keys(@message_ids)
+
   @spec encode_request(struct()) :: {:ok, binary()} | :error
   def encode_request(%module{} = request) do
     with {:ok, msg_id} <- message_id_for(module) do

--- a/lib/ib_ex/client/messages/responses.ex
+++ b/lib/ib_ex/client/messages/responses.ex
@@ -97,6 +97,12 @@ defmodule IbEx.Client.Messages.Responses do
     110 => Proto.ConfigResponse
   }
 
+  @doc """
+  Returns all response proto modules registered in the decoders map.
+  """
+  @spec decoder_modules() :: [module()]
+  def decoder_modules, do: Map.values(@decoders) |> Enum.uniq()
+
   @spec parse(binary(), atom(), boolean()) :: {:ok, any()} | {:error, :unexpected_error}
   def parse(str, :connecting, _trace_messages) do
     fields =

--- a/lib/ib_ex/client/subscriptions.ex
+++ b/lib/ib_ex/client/subscriptions.ex
@@ -6,8 +6,16 @@ defmodule IbEx.Client.Subscriptions do
 
   Supports two entry shapes:
 
-  * **Request entries** – bounded stream accumulation with a buffer, caller info, and optional timer.
-  * **Stream entries** – long-lived subscriptions with a subscriber pid, monitor ref, and opaque subscription ref.
+  * **Request entries** -- bounded stream accumulation with a buffer, caller info, and optional timer.
+  * **Stream entries** -- long-lived subscriptions with a subscriber pid, monitor ref, and opaque subscription ref.
+
+  ## Key Shapes
+
+  ETS keys use consistently shaped tagged tuples:
+
+  * `{:request_id, integer()}` -- for req_id-correlated conversations and streams
+  * `{:global, module()}` -- for global-correlated conversations (no req_id)
+  * `{:order_id, integer()}` -- for order lifecycle conversations (future use)
   """
 
   # ---------------------------------------------------------------------------
@@ -51,8 +59,10 @@ defmodule IbEx.Client.Subscriptions do
 
   Stores a map with `type: :request`, the GenServer `from` reference,
   an empty accumulation buffer, a timer reference, and the request module.
+
+  The ETS key is the tagged tuple passed as `key` (e.g. `{:request_id, 1}` or `{:global, Module}`).
   """
-  def register_request(table_ref, req_id, from, timer_ref, request_module) do
+  def register_request(table_ref, key, from, timer_ref, request_module) when is_tuple(key) do
     entry = %{
       type: :request,
       from: from,
@@ -61,7 +71,7 @@ defmodule IbEx.Client.Subscriptions do
       request_module: request_module
     }
 
-    :ets.insert(table_ref, {to_string(req_id), entry})
+    :ets.insert(table_ref, {key, entry})
     :ok
   end
 
@@ -70,8 +80,10 @@ defmodule IbEx.Client.Subscriptions do
 
   Stores a map with `type: :stream`, the subscriber pid, a monitor reference,
   an opaque subscription reference, and the request module.
+
+  The ETS key is the tagged tuple passed as `key` (e.g. `{:request_id, 1}`).
   """
-  def register_stream(table_ref, request_id, subscriber, monitor_ref, subscription_ref, request_module) do
+  def register_stream(table_ref, key, subscriber, monitor_ref, subscription_ref, request_module) when is_tuple(key) do
     entry = %{
       type: :stream,
       subscriber: subscriber,
@@ -80,7 +92,7 @@ defmodule IbEx.Client.Subscriptions do
       request_module: request_module
     }
 
-    :ets.insert(table_ref, {to_string(request_id), entry})
+    :ets.insert(table_ref, {key, entry})
     :ok
   end
 
@@ -94,9 +106,7 @@ defmodule IbEx.Client.Subscriptions do
   Returns `{:ok, updated_entry}` on success or `{:error, :missing_subscription}` if the key
   is not found.
   """
-  def append_response(table_ref, request_id, response) do
-    key = to_string(request_id)
-
+  def append_response(table_ref, key, response) when is_tuple(key) do
     case :ets.lookup(table_ref, key) do
       [{^key, %{type: :request, buffer: buffer} = entry}] ->
         updated_entry = %{entry | buffer: buffer ++ [response]}
@@ -119,9 +129,7 @@ defmodule IbEx.Client.Subscriptions do
   Returns `{:ok, buffer}` on success or `{:error, :missing_subscription}` if the key
   is not found.
   """
-  def complete_request(table_ref, request_id) do
-    key = to_string(request_id)
-
+  def complete_request(table_ref, key) when is_tuple(key) do
     case :ets.lookup(table_ref, key) do
       [{^key, %{type: :request, buffer: buffer}}] ->
         :ets.delete(table_ref, key)
@@ -139,8 +147,8 @@ defmodule IbEx.Client.Subscriptions do
   @doc """
   Removes any subscription entry by its key.
   """
-  def remove_subscription(table_ref, key) do
-    :ets.delete(table_ref, to_string(key))
+  def remove_subscription(table_ref, key) when is_tuple(key) do
+    :ets.delete(table_ref, key)
     :ok
   end
 

--- a/test/ib_ex/client/conversations_test.exs
+++ b/test/ib_ex/client/conversations_test.exs
@@ -2,6 +2,8 @@ defmodule IbEx.Client.ConversationsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Conversations
+  alias IbEx.Client.Messages.Requests
+  alias IbEx.Client.Messages.Responses
   alias IbEx.Client.Proto.Protobuf, as: Proto
 
   describe "conversation_for/1" do
@@ -25,6 +27,70 @@ defmodule IbEx.Client.ConversationsTest do
       refute Map.has_key?(shape, :cancel_request)
     end
 
+    test "returns stream shape for MarketDataRequest with full tick types" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.MarketDataRequest)
+
+      assert shape.type == :stream
+      assert shape.correlation == :req_id
+      assert Proto.TickPrice in shape.responses
+      assert Proto.TickSize in shape.responses
+      assert Proto.TickGeneric in shape.responses
+      assert Proto.TickString in shape.responses
+      assert Proto.TickOptionComputation in shape.responses
+      assert shape.cancel_request == Proto.CancelMarketData
+    end
+
+    test "returns global correlation for CurrentTimeRequest" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.CurrentTimeRequest)
+
+      assert shape.type == :request_response
+      assert shape.correlation == :global
+      assert shape.responses == [Proto.CurrentTime]
+    end
+
+    test "returns global bounded_stream for OpenOrdersRequest" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.OpenOrdersRequest)
+
+      assert shape.type == :bounded_stream
+      assert shape.correlation == :global
+      assert shape.responses == [Proto.OpenOrder]
+      assert shape.end_marker == Proto.OpenOrdersEnd
+    end
+
+    test "returns global bounded_stream for PositionsRequest" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.PositionsRequest)
+
+      assert shape.type == :bounded_stream
+      assert shape.correlation == :global
+      assert shape.responses == [Proto.Position]
+      assert shape.end_marker == Proto.PositionEnd
+      assert shape.cancel_request == Proto.CancelPositions
+    end
+
+    test "returns global bounded_stream for AccountDataRequest" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.AccountDataRequest)
+
+      assert shape.type == :bounded_stream
+      assert shape.correlation == :global
+      assert shape.responses == [Proto.AccountValue, Proto.PortfolioValue, Proto.AccountUpdateTime]
+      assert shape.end_marker == Proto.AccountDataEnd
+    end
+
+    test "returns global bounded_stream for CompletedOrdersRequest" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.CompletedOrdersRequest)
+
+      assert shape.type == :bounded_stream
+      assert shape.correlation == :global
+      assert shape.responses == [Proto.CompletedOrder]
+      assert shape.end_marker == Proto.CompletedOrdersEnd
+    end
+
+    test "returns command shape for fire-and-forget requests" do
+      assert {:ok, shape} = Conversations.conversation_for(Proto.GlobalCancelRequest)
+      assert shape.type == :command
+      assert shape.correlation == :global
+    end
+
     test "returns :error for unknown modules" do
       assert :error = Conversations.conversation_for(SomeUnknownModule)
     end
@@ -33,6 +99,29 @@ defmodule IbEx.Client.ConversationsTest do
   describe "end_marker?/1" do
     test "returns true for ContractDataEnd" do
       assert Conversations.end_marker?(Proto.ContractDataEnd)
+    end
+
+    test "returns true for all registered end markers" do
+      end_markers = [
+        Proto.ContractDataEnd,
+        Proto.ExecutionDetailsEnd,
+        Proto.HistoricalDataEnd,
+        Proto.AccountSummaryEnd,
+        Proto.PositionMultiEnd,
+        Proto.AccountUpdateMultiEnd,
+        Proto.SecDefOptParameterEnd,
+        Proto.HistoricalNewsEnd,
+        Proto.ReplaceFAEnd,
+        Proto.OpenOrdersEnd,
+        Proto.AccountDataEnd,
+        Proto.PositionEnd,
+        Proto.CompletedOrdersEnd
+      ]
+
+      for marker <- end_markers do
+        assert Conversations.end_marker?(marker),
+               "Expected #{inspect(marker)} to be recognized as an end marker"
+      end
     end
 
     test "returns false for ContractData (a regular response, not an end marker)" do
@@ -51,6 +140,17 @@ defmodule IbEx.Client.ConversationsTest do
   describe "cancel_request_for/1" do
     test "returns cancel module for ContractDataRequest" do
       assert {:ok, Proto.CancelContractData} = Conversations.cancel_request_for(Proto.ContractDataRequest)
+    end
+
+    test "returns cancel module for stream types" do
+      assert {:ok, Proto.CancelMarketData} = Conversations.cancel_request_for(Proto.MarketDataRequest)
+      assert {:ok, Proto.CancelRealTimeBars} = Conversations.cancel_request_for(Proto.RealTimeBarsRequest)
+      assert {:ok, Proto.CancelMarketDepth} = Conversations.cancel_request_for(Proto.MarketDepthRequest)
+      assert {:ok, Proto.CancelTickByTick} = Conversations.cancel_request_for(Proto.TickByTickRequest)
+      assert {:ok, Proto.CancelPnL} = Conversations.cancel_request_for(Proto.PnLRequest)
+      assert {:ok, Proto.CancelPnLSingle} = Conversations.cancel_request_for(Proto.PnLSingleRequest)
+      assert {:ok, Proto.CancelWshMetaData} = Conversations.cancel_request_for(Proto.WshMetaDataRequest)
+      assert {:ok, Proto.CancelWshEventData} = Conversations.cancel_request_for(Proto.WshEventDataRequest)
     end
 
     test "returns :error for MatchingSymbolsRequest (no cancel request)" do
@@ -75,44 +175,313 @@ defmodule IbEx.Client.ConversationsTest do
       assert Conversations.requests_for_response(Proto.SymbolSamples) == [Proto.MatchingSymbolsRequest]
     end
 
+    test "returns multiple request modules for shared response types" do
+      # OpenOrder is a response for both OpenOrdersRequest and AllOpenOrdersRequest
+      request_modules = Conversations.requests_for_response(Proto.OpenOrder)
+      assert Proto.OpenOrdersRequest in request_modules
+      assert Proto.AllOpenOrdersRequest in request_modules
+    end
+
     test "returns empty list for unknown response module" do
       assert Conversations.requests_for_response(SomeUnknownModule) == []
     end
   end
 
-  describe "cross-references with @message_ids and @decoders" do
-    alias IbEx.Client.Messages.Requests
-    alias IbEx.Client.Messages.Responses
-
-    test "all conversation request modules have a message_id in Requests" do
-      {:ok, contract_data_shape} = Conversations.conversation_for(Proto.ContractDataRequest)
-      assert {:ok, _id} = Requests.message_id_for(Proto.ContractDataRequest)
-
-      {:ok, matching_symbols_shape} = Conversations.conversation_for(Proto.MatchingSymbolsRequest)
-      assert {:ok, _id} = Requests.message_id_for(Proto.MatchingSymbolsRequest)
-
-      # Also verify cancel requests have message_ids
-      assert {:ok, _id} = Requests.message_id_for(contract_data_shape.cancel_request)
-
-      # MatchingSymbolsRequest has no cancel_request
-      refute Map.has_key?(matching_symbols_shape, :cancel_request)
+  describe "global_correlation?/1" do
+    test "returns true for request modules without req_id" do
+      assert Conversations.global_correlation?(Proto.CurrentTimeRequest)
+      assert Conversations.global_correlation?(Proto.CurrentTimeInMillisRequest)
+      assert Conversations.global_correlation?(Proto.ScannerParametersRequest)
+      assert Conversations.global_correlation?(Proto.NewsProvidersRequest)
+      assert Conversations.global_correlation?(Proto.FamilyCodesRequest)
+      assert Conversations.global_correlation?(Proto.MarketDepthExchangesRequest)
+      assert Conversations.global_correlation?(Proto.MarketRuleRequest)
+      assert Conversations.global_correlation?(Proto.OpenOrdersRequest)
+      assert Conversations.global_correlation?(Proto.AllOpenOrdersRequest)
+      assert Conversations.global_correlation?(Proto.AccountDataRequest)
+      assert Conversations.global_correlation?(Proto.PositionsRequest)
+      assert Conversations.global_correlation?(Proto.CompletedOrdersRequest)
+      assert Conversations.global_correlation?(Proto.NewsBulletinsRequest)
     end
 
-    test "all conversation response modules are in the decoders map" do
-      # ContractData is decoded at msg_id 10 (and 18 for bonds)
-      proto_payload = %Proto.ContractData{req_id: 1} |> Protobuf.encode()
-      wire_msg = <<10 + 200::big-integer-size(32), proto_payload::binary>>
-      assert {:ok, %Proto.ContractData{}} = Responses.parse(wire_msg, :connected, false)
+    test "returns false for request modules with req_id" do
+      refute Conversations.global_correlation?(Proto.ContractDataRequest)
+      refute Conversations.global_correlation?(Proto.MatchingSymbolsRequest)
+      refute Conversations.global_correlation?(Proto.MarketDataRequest)
+      refute Conversations.global_correlation?(Proto.HistoricalDataRequest)
+    end
 
-      # ContractDataEnd is decoded at msg_id 52
-      proto_payload = %Proto.ContractDataEnd{req_id: 1} |> Protobuf.encode()
-      wire_msg = <<52 + 200::big-integer-size(32), proto_payload::binary>>
-      assert {:ok, %Proto.ContractDataEnd{}} = Responses.parse(wire_msg, :connected, false)
+    test "returns false for unknown modules" do
+      refute Conversations.global_correlation?(SomeUnknownModule)
+    end
+  end
 
-      # SymbolSamples is decoded at msg_id 79
-      proto_payload = %Proto.SymbolSamples{req_id: 1} |> Protobuf.encode()
-      wire_msg = <<79 + 200::big-integer-size(32), proto_payload::binary>>
-      assert {:ok, %Proto.SymbolSamples{}} = Responses.parse(wire_msg, :connected, false)
+  describe "cross-reference: @message_ids coverage" do
+    # Cancel request modules in @message_ids are not conversation initiators;
+    # they appear as cancel_request values within conversation entries.
+    @cancel_modules [
+      Proto.CancelMarketData,
+      Proto.CancelMarketDepth,
+      Proto.CancelNewsBulletins,
+      Proto.CancelScannerSubscription,
+      Proto.CancelHistoricalData,
+      Proto.CancelRealTimeBars,
+      Proto.CancelFundamentalsData,
+      Proto.CancelCalculateImpliedVolatility,
+      Proto.CancelCalculateOptionPrice,
+      Proto.CancelAccountSummary,
+      Proto.CancelPositions,
+      Proto.CancelPositionsMulti,
+      Proto.CancelAccountUpdatesMulti,
+      Proto.CancelHistogramData,
+      Proto.CancelHeadTimestamp,
+      Proto.CancelPnL,
+      Proto.CancelPnLSingle,
+      Proto.CancelTickByTick,
+      Proto.CancelWshMetaData,
+      Proto.CancelWshEventData,
+      Proto.CancelContractData,
+      Proto.CancelHistoricalTicks,
+      Proto.UnsubscribeFromGroupEventsRequest
+    ]
+
+    test "every non-cancel request module in @message_ids has a @conversations entry" do
+      request_modules = Requests.request_modules()
+      conversation_modules = MapSet.new(Conversations.request_modules())
+
+      missing =
+        request_modules
+        |> Enum.reject(&(&1 in @cancel_modules))
+        |> Enum.reject(&MapSet.member?(conversation_modules, &1))
+
+      assert missing == [],
+             "The following request modules in @message_ids have no @conversations entry:\n" <>
+               Enum.map_join(missing, "\n", &"  - #{inspect(&1)}")
+    end
+
+    test "every cancel_request value in @conversations has a @message_ids entry" do
+      cancel_modules =
+        Conversations.request_modules()
+        |> Enum.map(&Conversations.cancel_request_for/1)
+        |> Enum.flat_map(fn
+          {:ok, mod} -> [mod]
+          :error -> []
+        end)
+        |> Enum.uniq()
+
+      missing =
+        Enum.reject(cancel_modules, fn mod ->
+          {:ok, _} = Requests.message_id_for(mod)
+          true
+        end)
+
+      assert missing == [],
+             "The following cancel request modules have no @message_ids entry:\n" <>
+               Enum.map_join(missing, "\n", &"  - #{inspect(&1)}")
+    end
+  end
+
+  describe "cross-reference: end markers in @decoders" do
+    # All end marker modules that appear in the @decoders response map
+    @end_marker_decoder_modules [
+      Proto.ContractDataEnd,
+      Proto.OpenOrdersEnd,
+      Proto.AccountDataEnd,
+      Proto.ExecutionDetailsEnd,
+      Proto.TickSnapshotEnd,
+      Proto.PositionEnd,
+      Proto.AccountSummaryEnd,
+      Proto.PositionMultiEnd,
+      Proto.AccountUpdateMultiEnd,
+      Proto.SecDefOptParameterEnd,
+      Proto.HistoricalNewsEnd,
+      Proto.CompletedOrdersEnd,
+      Proto.ReplaceFAEnd,
+      Proto.HistoricalDataEnd
+    ]
+
+    test "every end marker module in @decoders is referenced by a bounded stream conversation entry" do
+      all_decoder_modules = Responses.decoder_modules()
+
+      # Identify which decoder modules are end markers (name ends with "End")
+      end_marker_decoders =
+        all_decoder_modules
+        |> Enum.filter(fn mod ->
+          mod_name = mod |> Module.split() |> List.last()
+          String.ends_with?(mod_name, "End")
+        end)
+
+      # Verify our list is complete
+      assert MapSet.new(end_marker_decoders) == MapSet.new(@end_marker_decoder_modules),
+             "End marker decoder list mismatch. " <>
+               "In decoders: #{inspect(end_marker_decoders)}, expected: #{inspect(@end_marker_decoder_modules)}"
+
+      # Every end marker decoder must be referenced in a conversation
+      unreferenced =
+        Enum.reject(end_marker_decoders, fn marker ->
+          # Check if it appears as an end_marker or in responses of any conversation
+          Conversations.end_marker?(marker) or
+            Enum.any?(Conversations.request_modules(), fn req_mod ->
+              {:ok, shape} = Conversations.conversation_for(req_mod)
+              marker in shape.responses
+            end)
+        end)
+
+      assert unreferenced == [],
+             "The following end marker modules in @decoders are not referenced by any conversation:\n" <>
+               Enum.map_join(unreferenced, "\n", &"  - #{inspect(&1)}")
+    end
+  end
+
+  describe "conversation type distribution" do
+    test "registry contains all expected conversation types" do
+      types =
+        Conversations.request_modules()
+        |> Enum.map(fn mod ->
+          {:ok, shape} = Conversations.conversation_for(mod)
+          shape.type
+        end)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert :bounded_stream in types
+      assert :command in types
+      assert :request_response in types
+      assert :stream in types
+    end
+
+    test "registry contains both :req_id and :global correlation methods" do
+      correlations =
+        Conversations.request_modules()
+        |> Enum.map(fn mod ->
+          {:ok, shape} = Conversations.conversation_for(mod)
+          shape.correlation
+        end)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert correlations == [:global, :order_id, :req_id]
+    end
+  end
+
+  describe "register_request/5" do
+    alias IbEx.Client.Subscriptions
+
+    setup do
+      table_ref = Subscriptions.initialize()
+      %{table_ref: table_ref}
+    end
+
+    test "registers a :req_id conversation with {:request_id, N} key", %{table_ref: table_ref} do
+      from = {self(), make_ref()}
+
+      assert {:ok, key, req_id} =
+               Conversations.register_request(table_ref, Proto.MatchingSymbolsRequest, from, 5_000, self())
+
+      assert key == {:request_id, 1}
+      assert req_id == 1
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
+      assert entry.type == :request
+      assert entry.from == from
+      assert entry.buffer == []
+      assert entry.request_module == Proto.MatchingSymbolsRequest
+      assert is_reference(entry.timer_ref)
+    end
+
+    test "registers a :global conversation with {:global, module} key", %{table_ref: table_ref} do
+      from = {self(), make_ref()}
+
+      assert {:ok, key, nil} =
+               Conversations.register_request(table_ref, Proto.CurrentTimeRequest, from, 5_000, self())
+
+      assert key == {:global, Proto.CurrentTimeRequest}
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
+      assert entry.type == :request
+      assert entry.from == from
+      assert entry.request_module == Proto.CurrentTimeRequest
+    end
+
+    test "registers an :order_id conversation with {:order_id, N} key", %{table_ref: table_ref} do
+      from = {self(), make_ref()}
+
+      assert {:ok, key, order_id} =
+               Conversations.register_request(table_ref, Proto.PlaceOrderRequest, from, 5_000, self())
+
+      assert key == {:order_id, 1}
+      assert order_id == 1
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
+      assert entry.type == :request
+      assert entry.request_module == Proto.PlaceOrderRequest
+    end
+
+    test "allocates incrementing req_ids for successive :req_id registrations", %{table_ref: table_ref} do
+      from = {self(), make_ref()}
+
+      assert {:ok, {:request_id, 1}, 1} =
+               Conversations.register_request(table_ref, Proto.MatchingSymbolsRequest, from, 5_000, self())
+
+      assert {:ok, {:request_id, 2}, 2} =
+               Conversations.register_request(table_ref, Proto.HeadTimestampRequest, from, 5_000, self())
+    end
+
+    test "returns :error for unknown request module", %{table_ref: table_ref} do
+      from = {self(), make_ref()}
+
+      assert :error = Conversations.register_request(table_ref, SomeUnknownModule, from, 5_000, self())
+    end
+
+    test "sets up a timeout timer that sends {:request_timeout, key}", %{table_ref: table_ref} do
+      from = {self(), make_ref()}
+
+      assert {:ok, key, _req_id} =
+               Conversations.register_request(table_ref, Proto.MatchingSymbolsRequest, from, 50, self())
+
+      assert_receive {:request_timeout, ^key}, 200
+    end
+  end
+
+  describe "register_stream/3" do
+    alias IbEx.Client.Subscriptions
+
+    setup do
+      table_ref = Subscriptions.initialize()
+      %{table_ref: table_ref}
+    end
+
+    test "registers a stream subscription with {:request_id, N} key", %{table_ref: table_ref} do
+      assert {:ok, req_id, subscription_ref} =
+               Conversations.register_stream(table_ref, Proto.MarketDataRequest, self())
+
+      assert req_id == 1
+      assert is_reference(subscription_ref)
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, {:request_id, 1})
+      assert entry.type == :stream
+      assert entry.subscriber == self()
+      assert entry.subscription_ref == subscription_ref
+      assert entry.request_module == Proto.MarketDataRequest
+      assert is_reference(entry.monitor_ref)
+    end
+
+    test "returns :error for non-stream conversation types", %{table_ref: table_ref} do
+      assert :error = Conversations.register_stream(table_ref, Proto.MatchingSymbolsRequest, self())
+      assert :error = Conversations.register_stream(table_ref, Proto.ContractDataRequest, self())
+      assert :error = Conversations.register_stream(table_ref, Proto.GlobalCancelRequest, self())
+    end
+
+    test "returns :error for unknown modules", %{table_ref: table_ref} do
+      assert :error = Conversations.register_stream(table_ref, SomeUnknownModule, self())
+    end
+
+    test "monitors the subscriber process", %{table_ref: table_ref} do
+      assert {:ok, _req_id, _sub_ref} =
+               Conversations.register_stream(table_ref, Proto.MarketDataRequest, self())
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, {:request_id, 1})
+      assert is_reference(entry.monitor_ref)
     end
   end
 end

--- a/test/ib_ex/client/subscriptions_test.exs
+++ b/test/ib_ex/client/subscriptions_test.exs
@@ -30,7 +30,7 @@ defmodule IbEx.Client.SubscriptionsTest do
     test "advances the counter without inserting a subscription entry", %{table_ref: table_ref} do
       request_id = Subscriptions.allocate_request_id(table_ref)
 
-      assert Subscriptions.lookup(table_ref, to_string(request_id)) == {:error, :missing_subscription}
+      assert Subscriptions.lookup(table_ref, {:request_id, request_id}) == {:error, :missing_subscription}
     end
   end
 
@@ -41,12 +41,13 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "register_request/5" do
     test "stores a request entry that can be looked up", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
+      key = {:request_id, req_id}
       from = {self(), make_ref()}
       timer_ref = make_ref()
 
-      assert :ok = Subscriptions.register_request(table_ref, req_id, from, timer_ref, SomeRequestModule)
+      assert :ok = Subscriptions.register_request(table_ref, key, from, timer_ref, SomeRequestModule)
 
-      assert {:ok, entry} = Subscriptions.lookup(table_ref, to_string(req_id))
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
 
       assert entry.type == :request
       assert entry.from == from
@@ -57,11 +58,36 @@ defmodule IbEx.Client.SubscriptionsTest do
 
     test "stores entry with nil timer_ref", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
+      key = {:request_id, req_id}
 
-      assert :ok = Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      assert :ok = Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      assert {:ok, entry} = Subscriptions.lookup(table_ref, to_string(req_id))
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
       assert entry.timer_ref == nil
+    end
+
+    test "works with {:global, module} keys", %{table_ref: table_ref} do
+      key = {:global, SomeGlobalModule}
+      from = {self(), make_ref()}
+      timer_ref = make_ref()
+
+      assert :ok = Subscriptions.register_request(table_ref, key, from, timer_ref, SomeGlobalModule)
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
+      assert entry.type == :request
+      assert entry.request_module == SomeGlobalModule
+    end
+
+    test "works with {:order_id, integer} keys", %{table_ref: table_ref} do
+      key = {:order_id, 42}
+      from = {self(), make_ref()}
+      timer_ref = make_ref()
+
+      assert :ok = Subscriptions.register_request(table_ref, key, from, timer_ref, SomeOrderModule)
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
+      assert entry.type == :request
+      assert entry.request_module == SomeOrderModule
     end
   end
 
@@ -72,6 +98,7 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "register_stream/6" do
     test "stores a stream entry that can be looked up", %{table_ref: table_ref} do
       request_id = Subscriptions.allocate_request_id(table_ref)
+      key = {:request_id, request_id}
       subscriber = self()
       monitor_ref = make_ref()
       subscription_ref = make_ref()
@@ -79,14 +106,14 @@ defmodule IbEx.Client.SubscriptionsTest do
       assert :ok =
                Subscriptions.register_stream(
                  table_ref,
-                 request_id,
+                 key,
                  subscriber,
                  monitor_ref,
                  subscription_ref,
                  StreamModule
                )
 
-      assert {:ok, entry} = Subscriptions.lookup(table_ref, to_string(request_id))
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, key)
 
       assert entry.type == :stream
       assert entry.subscriber == subscriber
@@ -103,27 +130,29 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "append_response/3" do
     test "accumulates responses into the buffer in order", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      assert {:ok, entry1} = Subscriptions.append_response(table_ref, req_id, :response_a)
+      assert {:ok, entry1} = Subscriptions.append_response(table_ref, key, :response_a)
       assert entry1.buffer == [:response_a]
 
-      assert {:ok, entry2} = Subscriptions.append_response(table_ref, req_id, :response_b)
+      assert {:ok, entry2} = Subscriptions.append_response(table_ref, key, :response_b)
       assert entry2.buffer == [:response_a, :response_b]
 
-      assert {:ok, entry3} = Subscriptions.append_response(table_ref, req_id, :response_c)
+      assert {:ok, entry3} = Subscriptions.append_response(table_ref, key, :response_c)
       assert entry3.buffer == [:response_a, :response_b, :response_c]
     end
 
     test "returns error for non-existent key", %{table_ref: table_ref} do
-      assert {:error, :missing_subscription} = Subscriptions.append_response(table_ref, 999, :response)
+      assert {:error, :missing_subscription} = Subscriptions.append_response(table_ref, {:request_id, 999}, :response)
     end
 
     test "returns error when entry is a stream (not a request)", %{table_ref: table_ref} do
       request_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_stream(table_ref, request_id, self(), make_ref(), make_ref(), StreamMod)
+      key = {:request_id, request_id}
+      Subscriptions.register_stream(table_ref, key, self(), make_ref(), make_ref(), StreamMod)
 
-      assert {:error, :missing_subscription} = Subscriptions.append_response(table_ref, request_id, :response)
+      assert {:error, :missing_subscription} = Subscriptions.append_response(table_ref, key, :response)
     end
   end
 
@@ -134,36 +163,39 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "complete_request/2" do
     test "returns accumulated buffer and deletes the entry", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      Subscriptions.append_response(table_ref, req_id, :resp_1)
-      Subscriptions.append_response(table_ref, req_id, :resp_2)
+      Subscriptions.append_response(table_ref, key, :resp_1)
+      Subscriptions.append_response(table_ref, key, :resp_2)
 
-      assert {:ok, buffer} = Subscriptions.complete_request(table_ref, req_id)
+      assert {:ok, buffer} = Subscriptions.complete_request(table_ref, key)
       assert buffer == [:resp_1, :resp_2]
 
       # Entry should be deleted
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, to_string(req_id))
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, key)
     end
 
     test "returns empty buffer when no responses were appended", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      assert {:ok, buffer} = Subscriptions.complete_request(table_ref, req_id)
+      assert {:ok, buffer} = Subscriptions.complete_request(table_ref, key)
       assert buffer == []
     end
 
     test "returns error for non-existent key", %{table_ref: table_ref} do
-      assert {:error, :missing_subscription} = Subscriptions.complete_request(table_ref, 999)
+      assert {:error, :missing_subscription} = Subscriptions.complete_request(table_ref, {:request_id, 999})
     end
 
     test "returns error when called twice (entry already deleted)", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      assert {:ok, []} = Subscriptions.complete_request(table_ref, req_id)
-      assert {:error, :missing_subscription} = Subscriptions.complete_request(table_ref, req_id)
+      assert {:ok, []} = Subscriptions.complete_request(table_ref, key)
+      assert {:error, :missing_subscription} = Subscriptions.complete_request(table_ref, key)
     end
   end
 
@@ -174,22 +206,24 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "remove_subscription/2" do
     test "removes a request entry", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      assert :ok = Subscriptions.remove_subscription(table_ref, req_id)
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, to_string(req_id))
+      assert :ok = Subscriptions.remove_subscription(table_ref, key)
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, key)
     end
 
     test "removes a stream entry", %{table_ref: table_ref} do
       request_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_stream(table_ref, request_id, self(), make_ref(), make_ref(), StreamMod)
+      key = {:request_id, request_id}
+      Subscriptions.register_stream(table_ref, key, self(), make_ref(), make_ref(), StreamMod)
 
-      assert :ok = Subscriptions.remove_subscription(table_ref, request_id)
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, to_string(request_id))
+      assert :ok = Subscriptions.remove_subscription(table_ref, key)
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, key)
     end
 
     test "returns :ok even if key does not exist", %{table_ref: table_ref} do
-      assert :ok = Subscriptions.remove_subscription(table_ref, 42)
+      assert :ok = Subscriptions.remove_subscription(table_ref, {:request_id, 42})
     end
   end
 
@@ -200,12 +234,13 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "lookup_by_subscription_ref/2" do
     test "finds a stream entry by its subscription_ref", %{table_ref: table_ref} do
       request_id = Subscriptions.allocate_request_id(table_ref)
+      key = {:request_id, request_id}
       subscription_ref = make_ref()
 
-      Subscriptions.register_stream(table_ref, request_id, self(), make_ref(), subscription_ref, StreamMod)
+      Subscriptions.register_stream(table_ref, key, self(), make_ref(), subscription_ref, StreamMod)
 
-      assert {:ok, key, entry} = Subscriptions.lookup_by_subscription_ref(table_ref, subscription_ref)
-      assert key == to_string(request_id)
+      assert {:ok, found_key, entry} = Subscriptions.lookup_by_subscription_ref(table_ref, subscription_ref)
+      assert found_key == key
       assert entry.type == :stream
       assert entry.subscription_ref == subscription_ref
       assert entry.request_module == StreamMod
@@ -218,7 +253,8 @@ defmodule IbEx.Client.SubscriptionsTest do
 
     test "does not match request entries", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
       assert {:error, :missing_subscription} =
                Subscriptions.lookup_by_subscription_ref(table_ref, make_ref())
@@ -232,16 +268,18 @@ defmodule IbEx.Client.SubscriptionsTest do
   describe "lookup/2" do
     test "returns full entry map for rich request entries", %{table_ref: table_ref} do
       req_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_request(table_ref, req_id, {self(), make_ref()}, nil, SomeMod)
+      key = {:request_id, req_id}
+      Subscriptions.register_request(table_ref, key, {self(), make_ref()}, nil, SomeMod)
 
-      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, to_string(req_id))
+      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, key)
     end
 
     test "returns full entry map for stream entries", %{table_ref: table_ref} do
       request_id = Subscriptions.allocate_request_id(table_ref)
-      Subscriptions.register_stream(table_ref, request_id, self(), make_ref(), make_ref(), StreamMod)
+      key = {:request_id, request_id}
+      Subscriptions.register_stream(table_ref, key, self(), make_ref(), make_ref(), StreamMod)
 
-      assert {:ok, %{type: :stream}} = Subscriptions.lookup(table_ref, to_string(request_id))
+      assert {:ok, %{type: :stream}} = Subscriptions.lookup(table_ref, key)
     end
 
     test "returns error for missing key", %{table_ref: table_ref} do

--- a/test/ib_ex/client_test.exs
+++ b/test/ib_ex/client_test.exs
@@ -136,9 +136,9 @@ defmodule IbEx.ClientTest do
 
       assert {:noreply, ^state} = Client.handle_call({:request, proto_msg, []}, from, state)
 
-      # Verify ETS entry was created with req_id "1"
+      # Verify ETS entry was created with req_id {:request_id, 1}
       assert {:ok, %{type: :request, request_module: IbEx.Client.Proto.Protobuf.MatchingSymbolsRequest}} =
-               Subscriptions.lookup(table_ref, "1")
+               Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Simulate receiving a SymbolSamples response with req_id=1
       response = %IbEx.Client.Proto.Protobuf.SymbolSamples{req_id: 1, contract_descriptions: []}
@@ -152,7 +152,7 @@ defmodule IbEx.ClientTest do
       assert_receive {_ref, {:ok, %IbEx.Client.Proto.Protobuf.SymbolSamples{req_id: 1}}}
 
       # ETS entry should be cleaned up
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:request_id, 1})
     end
   end
 
@@ -171,7 +171,7 @@ defmodule IbEx.ClientTest do
 
       # Verify ETS entry
       assert {:ok, %{type: :request, request_module: IbEx.Client.Proto.Protobuf.ContractDataRequest}} =
-               Subscriptions.lookup(table_ref, "1")
+               Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Simulate receiving two ContractData responses (msg_id=10, wire_id=210)
       contract_data_1 = %IbEx.Client.Proto.Protobuf.ContractData{req_id: 1}
@@ -202,7 +202,7 @@ defmodule IbEx.ClientTest do
       assert Enum.all?(buffer, &match?(%IbEx.Client.Proto.Protobuf.ContractData{req_id: 1}, &1))
 
       # ETS entry should be cleaned up
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:request_id, 1})
     end
   end
 
@@ -217,7 +217,7 @@ defmodule IbEx.ClientTest do
       assert {:noreply, ^state} = Client.handle_call({:request, proto_msg, []}, from, state)
 
       # Verify ETS entry exists
-      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, "1")
+      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Simulate receiving an ErrorMessage with id=1 (msg_id=4, wire_id=204)
       error_proto = %IbEx.Client.Proto.Protobuf.ErrorMessage{id: 1, error_code: 200, error_msg: "No security found"}
@@ -229,7 +229,7 @@ defmodule IbEx.ClientTest do
       assert_receive {_ref, {:error, %IbEx.Client.Types.Error{id: 1, code: 200, message: "No security found"}}}
 
       # ETS entry should be cleaned up
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:request_id, 1})
     end
   end
 
@@ -245,23 +245,23 @@ defmodule IbEx.ClientTest do
                Client.handle_call({:request, proto_msg, [timeout: 100]}, from, state)
 
       # Verify ETS entry exists
-      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, "1")
+      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Simulate the timeout firing
-      assert {:noreply, ^state} = Client.handle_info({:request_timeout, "1"}, state)
+      assert {:noreply, ^state} = Client.handle_info({:request_timeout, {:request_id, 1}}, state)
 
       # Caller should receive {:error, :timeout}
       assert_receive {_ref, {:error, :timeout}}
 
       # ETS entry should be cleaned up
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:request_id, 1})
     end
 
     test "timeout is a no-op when conversation already completed" do
       {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
 
-      # No ETS entry for key "999" -- already completed
-      assert {:noreply, ^state} = Client.handle_info({:request_timeout, "999"}, state)
+      # No ETS entry for key {:request_id, 999} -- already completed
+      assert {:noreply, ^state} = Client.handle_info({:request_timeout, {:request_id, 999}}, state)
     end
   end
 
@@ -279,8 +279,8 @@ defmodule IbEx.ClientTest do
 
       assert is_reference(subscription_ref)
 
-      # Verify ETS entry was created as a :stream type with req_id "1"
-      assert {:ok, entry} = Subscriptions.lookup(table_ref, "1")
+      # Verify ETS entry was created as a :stream type with key {:request_id, 1}
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, {:request_id, 1})
       assert entry.type == :stream
       assert entry.subscriber == self()
       assert entry.subscription_ref == subscription_ref
@@ -346,7 +346,7 @@ defmodule IbEx.ClientTest do
       assert_receive {:ib_ex, ^subscription_ref, %IbEx.Client.Proto.Protobuf.TickPrice{price: 151.00}}
 
       # ETS entry should still exist
-      assert {:ok, %{type: :stream}} = Subscriptions.lookup(table_ref, "1")
+      assert {:ok, %{type: :stream}} = Subscriptions.lookup(table_ref, {:request_id, 1})
     end
 
     test "delivers error messages to stream subscribers" do
@@ -392,7 +392,8 @@ defmodule IbEx.ClientTest do
       assert_receive {:tws_sent, _subscribe_msg}
 
       # Verify ETS entry exists
-      assert {:ok, %{type: :stream, monitor_ref: monitor_ref}} = Subscriptions.lookup(table_ref, "1")
+      assert {:ok, %{type: :stream, monitor_ref: monitor_ref}} =
+               Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Unsubscribe
       assert {:reply, :ok, ^state} =
@@ -409,7 +410,7 @@ defmodule IbEx.ClientTest do
       assert decoded.req_id == 1
 
       # ETS entry should be cleaned up
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Monitor should have been removed (verify by checking it's not a valid monitor)
       refute Process.read_timer(monitor_ref)
@@ -468,7 +469,8 @@ defmodule IbEx.ClientTest do
       assert_receive {:tws_sent, _subscribe_msg}
 
       # Verify ETS entry exists and grab the monitor ref
-      assert {:ok, %{type: :stream, monitor_ref: monitor_ref}} = Subscriptions.lookup(table_ref, "1")
+      assert {:ok, %{type: :stream, monitor_ref: monitor_ref}} =
+               Subscriptions.lookup(table_ref, {:request_id, 1})
 
       # Kill the subscriber and wait for confirmation
       Process.exit(subscriber, :kill)
@@ -494,7 +496,7 @@ defmodule IbEx.ClientTest do
       assert decoded.req_id == 1
 
       # ETS entry should be cleaned up
-      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, "1")
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:request_id, 1})
     end
 
     test "handle_info(:DOWN) is a no-op for unknown monitor refs" do
@@ -504,6 +506,101 @@ defmodule IbEx.ClientTest do
 
       assert {:noreply, ^state} =
                Client.handle_info({:DOWN, unknown_monitor, :process, self(), :normal}, state)
+    end
+  end
+
+  describe "request/3 global correlation :request_response path" do
+    test "returns {:ok, response} for CurrentTimeRequest (no req_id)" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      table_ref = state.subscriptions_table_ref
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.CurrentTimeRequest{}
+      from = {self(), make_ref()}
+
+      assert {:noreply, ^state} = Client.handle_call({:request, proto_msg, []}, from, state)
+
+      # Verify ETS entry was created with global key
+      global_key = {:global, IbEx.Client.Proto.Protobuf.CurrentTimeRequest}
+
+      assert {:ok, %{type: :request, request_module: IbEx.Client.Proto.Protobuf.CurrentTimeRequest}} =
+               Subscriptions.lookup(table_ref, global_key)
+
+      # Simulate receiving a CurrentTime response (msg_id=49, wire_id=249) -- no req_id field
+      response = %IbEx.Client.Proto.Protobuf.CurrentTime{current_time: 1_700_000_000}
+      proto_payload = Protobuf.encode(response)
+      wire_msg = <<249::big-integer-size(32), proto_payload::binary>>
+
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_msg}, state)
+
+      # The caller should receive the reply
+      assert_receive {_ref, {:ok, %IbEx.Client.Proto.Protobuf.CurrentTime{current_time: 1_700_000_000}}}
+
+      # ETS entry should be cleaned up
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, global_key)
+    end
+  end
+
+  describe "request/3 global correlation :bounded_stream path" do
+    test "accumulates OpenOrder responses and returns buffer on OpenOrdersEnd" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      table_ref = state.subscriptions_table_ref
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.OpenOrdersRequest{}
+      from = {self(), make_ref()}
+
+      assert {:noreply, ^state} = Client.handle_call({:request, proto_msg, []}, from, state)
+
+      # Verify ETS entry was created with global key
+      global_key = {:global, IbEx.Client.Proto.Protobuf.OpenOrdersRequest}
+
+      assert {:ok, %{type: :request, request_module: IbEx.Client.Proto.Protobuf.OpenOrdersRequest}} =
+               Subscriptions.lookup(table_ref, global_key)
+
+      # Simulate receiving an OpenOrder response (msg_id=5, wire_id=205) -- no req_id field
+      open_order = %IbEx.Client.Proto.Protobuf.OpenOrder{order_id: 1}
+      wire_msg = <<205::big-integer-size(32), Protobuf.encode(open_order)::binary>>
+
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_msg}, state)
+
+      # Should not have replied yet
+      refute_receive {_ref, {:ok, _}}
+
+      # Simulate receiving OpenOrdersEnd (msg_id=53, wire_id=253) -- no req_id
+      end_marker = %IbEx.Client.Proto.Protobuf.OpenOrdersEnd{}
+      wire_end = <<253::big-integer-size(32), Protobuf.encode(end_marker)::binary>>
+
+      assert {:noreply, ^state} = Client.handle_cast({:process_message, wire_end}, state)
+
+      # Now the caller should receive the accumulated buffer
+      assert_receive {_ref, {:ok, buffer}}
+      assert length(buffer) == 1
+      assert [%IbEx.Client.Proto.Protobuf.OpenOrder{order_id: 1}] = buffer
+
+      # ETS entry should be cleaned up
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, global_key)
+    end
+
+    test "global correlation timeout fires and cleans up" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      table_ref = state.subscriptions_table_ref
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.OpenOrdersRequest{}
+      from = {self(), make_ref()}
+
+      assert {:noreply, ^state} =
+               Client.handle_call({:request, proto_msg, [timeout: 100]}, from, state)
+
+      global_key = {:global, IbEx.Client.Proto.Protobuf.OpenOrdersRequest}
+      assert {:ok, %{type: :request}} = Subscriptions.lookup(table_ref, global_key)
+
+      # Simulate the timeout firing
+      assert {:noreply, ^state} = Client.handle_info({:request_timeout, global_key}, state)
+
+      # Caller should receive {:error, :timeout}
+      assert_receive {_ref, {:error, :timeout}}
+
+      # ETS entry should be cleaned up
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, global_key)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Populates `@conversations` map from 3 entries to the full registry: 16 request/response, 16 bounded stream, 11 continuous stream, and 16 command (fire-and-forget) types
- Adds global correlation support for requests without `req_id` (OpenOrders, Positions, AccountData, CurrentTime, etc.) using `{:global, request_module}` as ETS key
- Adds cross-reference tests ensuring every request module in `@message_ids` has a `@conversations` entry and every end marker in `@decoders` is referenced by a bounded stream entry
- Unblocks all 11 downstream thematic module tickets

## Test plan
- [x] Cross-reference: every non-cancel request module in `@message_ids` has a `@conversations` entry
- [x] Cross-reference: every `*End` module in `@decoders` is referenced by a bounded stream entry
- [x] Global correlation request/response dispatch (CurrentTimeRequest)
- [x] Global correlation bounded stream dispatch (OpenOrdersRequest → OpenOrder* → OpenOrdersEnd)
- [x] Global correlation timeout fires and cleans up ETS
- [x] All conversation types and correlation methods represented
- [x] All 13 end markers verified
- [x] Cancel request modules validated for all stream types