### PR TITLE
Add Client.MarketData thematic module

### DIFF
--- a/lib/ib_ex/client/market_data.ex
+++ b/lib/ib_ex/client/market_data.ex
@@ -1,0 +1,173 @@
+defmodule IbEx.Client.MarketData do
+  @moduledoc """
+  Thematic module for market data operations.
+
+  Provides high-level functions for subscribing to real-time market data streams
+  and tick-by-tick data. This module is stateless -- it builds proto request
+  structs and delegates to `Client.subscribe/3` and `Client.unsubscribe/2`.
+
+  ## Functions
+
+  * `subscribe/3` - Subscribes to a continuous market data stream for a contract
+    (TickPrice, TickSize, TickString, TickGeneric, TickOptionComputation).
+  * `snapshot/3` - Requests a market data snapshot (same stream, ends with TickSnapshotEnd).
+  * `unsubscribe/2` - Cancels a market data or tick-by-tick subscription.
+  * `tick_by_tick_subscribe/3` - Subscribes to tick-by-tick data for a contract.
+  * `tick_by_tick_unsubscribe/2` - Cancels a tick-by-tick subscription.
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Mapper
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Types.Contract, as: DomainContract
+
+  @doc """
+  Subscribes to a continuous market data stream for the given contract.
+
+  Builds a `MarketDataRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with
+  TickPrice, TickSize, TickString, TickGeneric, and TickOptionComputation protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:generic_tick_list` - Comma-separated string of generic tick types (default: `""`)
+  * `:regulatory_snapshot` - Whether to request a regulatory snapshot (default: `false`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, ref} = MarketData.subscribe(client, contract)
+
+  """
+  @spec subscribe(pid(), struct(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def subscribe(client, contract, opts \\ [])
+
+  def subscribe(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_market_data_request(proto_contract, opts)
+    Client.subscribe(client, request, opts)
+  end
+
+  def subscribe(client, %DomainContract{} = contract, opts) do
+    subscribe(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Requests a market data snapshot for the given contract.
+
+  Same as `subscribe/3` but sets the snapshot flag to `true` on the request.
+  The stream ends with a `TickSnapshotEnd` message, after which no more ticks arrive.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:generic_tick_list` - Comma-separated string of generic tick types (default: `""`)
+  * `:regulatory_snapshot` - Whether to request a regulatory snapshot (default: `false`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, ref} = MarketData.snapshot(client, contract)
+
+  """
+  @spec snapshot(pid(), struct(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def snapshot(client, contract, opts \\ [])
+
+  def snapshot(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_market_data_request(proto_contract, Keyword.put(opts, :snapshot, true))
+    Client.subscribe(client, request, opts)
+  end
+
+  def snapshot(client, %DomainContract{} = contract, opts) do
+    snapshot(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Cancels a market data or tick-by-tick subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends the appropriate cancel
+  message (CancelMarketData or CancelTickByTick) and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = MarketData.unsubscribe(client, subscription_ref)
+
+  """
+  @spec unsubscribe(pid(), reference()) :: :ok | {:error, :not_found}
+  def unsubscribe(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  @doc """
+  Subscribes to tick-by-tick data for the given contract.
+
+  Builds a `TickByTickRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with
+  `TickByTickData` protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:tick_type` - The tick type string: `"Last"`, `"AllLast"`, `"BidAsk"`, or `"MidPoint"` (default: `"Last"`)
+  * `:number_of_ticks` - Number of ticks to return (default: `0`, meaning all)
+  * `:ignore_size` - Whether to ignore size in tick data (default: `false`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, ref} = MarketData.tick_by_tick_subscribe(client, contract, tick_type: "BidAsk")
+
+  """
+  @spec tick_by_tick_subscribe(pid(), struct(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def tick_by_tick_subscribe(client, contract, opts \\ [])
+
+  def tick_by_tick_subscribe(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_tick_by_tick_request(proto_contract, opts)
+    Client.subscribe(client, request, opts)
+  end
+
+  def tick_by_tick_subscribe(client, %DomainContract{} = contract, opts) do
+    tick_by_tick_subscribe(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Cancels a tick-by-tick subscription.
+
+  Alias for `unsubscribe/2` -- both market data and tick-by-tick subscriptions
+  are cancelled through the same `Client.unsubscribe/2` mechanism.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = MarketData.tick_by_tick_unsubscribe(client, subscription_ref)
+
+  """
+  @spec tick_by_tick_unsubscribe(pid(), reference()) :: :ok | {:error, :not_found}
+  def tick_by_tick_unsubscribe(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  defp build_market_data_request(proto_contract, opts) do
+    %Proto.MarketDataRequest{
+      contract: proto_contract,
+      generic_tick_list: Keyword.get(opts, :generic_tick_list, ""),
+      snapshot: Keyword.get(opts, :snapshot, false),
+      regulatory_snapshot: Keyword.get(opts, :regulatory_snapshot, false)
+    }
+  end
+
+  defp build_tick_by_tick_request(proto_contract, opts) do
+    %Proto.TickByTickRequest{
+      contract: proto_contract,
+      tick_type: Keyword.get(opts, :tick_type, "Last"),
+      number_of_ticks: Keyword.get(opts, :number_of_ticks, 0),
+      ignore_size: Keyword.get(opts, :ignore_size, false)
+    }
+  end
+end

--- a/test/ib_ex/client/market_data_test.exs
+++ b/test/ib_ex/client/market_data_test.exs
@@ -1,0 +1,229 @@
+defmodule IbEx.Client.MarketDataTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.MarketData
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Types.Contract, as: DomainContract
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @tick_price_wire_id 201
+  @tick_size_wire_id 202
+  @tick_snapshot_end_wire_id 257
+  @tick_by_tick_data_wire_id 299
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "subscribe/3" do
+    test "subscribes to market data and receives TickPrice messages" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.subscribe(client, contract)
+      assert is_reference(ref)
+
+      # Inject a TickPrice message targeting req_id=1
+      tick_price = %Proto.TickPrice{req_id: 1, tick_type: 1, price: 150.25, size: "100", attr_mask: 0}
+      Client.process_message(client, wire_message(@tick_price_wire_id, tick_price))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickPrice{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.tick_type == 1
+      assert received.price == 150.25
+      assert received.size == "100"
+    end
+
+    test "subscribes to market data and receives TickSize messages" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.subscribe(client, contract)
+
+      tick_size = %Proto.TickSize{req_id: 1, tick_type: 0, size: "500"}
+      Client.process_message(client, wire_message(@tick_size_wire_id, tick_size))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickSize{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.tick_type == 0
+      assert received.size == "500"
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.subscribe(client, proto_contract)
+      assert is_reference(ref)
+
+      tick_price = %Proto.TickPrice{req_id: 1, tick_type: 2, price: 151.00}
+      Client.process_message(client, wire_message(@tick_price_wire_id, tick_price))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickPrice{price: 151.00}}, 1_000
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+      contract = %DomainContract{symbol: "INVALID", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.subscribe(client, contract)
+
+      error_proto = %Proto.ErrorMessage{id: 1, error_code: 200, error_msg: "No security definition found"}
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No security definition found"
+    end
+  end
+
+  describe "snapshot/3" do
+    test "subscribes with snapshot flag and receives ticks followed by TickSnapshotEnd" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.snapshot(client, contract)
+      assert is_reference(ref)
+
+      # Inject tick data
+      tick_price = %Proto.TickPrice{req_id: 1, tick_type: 1, price: 150.25, size: "100"}
+      Client.process_message(client, wire_message(@tick_price_wire_id, tick_price))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickPrice{price: 150.25}}, 1_000
+
+      tick_size = %Proto.TickSize{req_id: 1, tick_type: 0, size: "200"}
+      Client.process_message(client, wire_message(@tick_size_wire_id, tick_size))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickSize{size: "200"}}, 1_000
+
+      # Inject snapshot end marker
+      snapshot_end = %Proto.TickSnapshotEnd{req_id: 1}
+      Client.process_message(client, wire_message(@tick_snapshot_end_wire_id, snapshot_end))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickSnapshotEnd{req_id: 1}}, 1_000
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+      proto_contract = %Proto.Contract{symbol: "MSFT", sec_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.snapshot(client, proto_contract)
+      assert is_reference(ref)
+    end
+  end
+
+  describe "unsubscribe/2" do
+    test "cancels an active market data subscription" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.subscribe(client, contract)
+      assert :ok = MarketData.unsubscribe(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = MarketData.unsubscribe(client, fake_ref)
+    end
+  end
+
+  describe "tick_by_tick_subscribe/3" do
+    test "subscribes to tick-by-tick data and receives TickByTickData messages" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.tick_by_tick_subscribe(client, contract, tick_type: "Last")
+      assert is_reference(ref)
+
+      tick_last = %Proto.HistoricalTickLast{time: 1_700_000_000, price: 150.50, size: "1"}
+
+      tick_data = %Proto.TickByTickData{
+        req_id: 1,
+        tick_type: 1,
+        tick: {:historical_tick_last, tick_last}
+      }
+
+      Client.process_message(client, wire_message(@tick_by_tick_data_wire_id, tick_data))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickByTickData{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.tick_type == 1
+      assert {:historical_tick_last, last} = received.tick
+      assert last.price == 150.50
+      assert last.size == "1"
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.tick_by_tick_subscribe(client, proto_contract, tick_type: "BidAsk")
+      assert is_reference(ref)
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+      contract = %DomainContract{symbol: "INVALID", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.tick_by_tick_subscribe(client, contract)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 321,
+        error_msg: "Error validating request: Tick-by-tick data is not available"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.code == 321
+      assert error.message == "Error validating request: Tick-by-tick data is not available"
+    end
+  end
+
+  describe "tick_by_tick_unsubscribe/2" do
+    test "cancels an active tick-by-tick subscription" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = MarketData.tick_by_tick_subscribe(client, contract)
+      assert :ok = MarketData.tick_by_tick_unsubscribe(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = MarketData.tick_by_tick_unsubscribe(client, fake_ref)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `IbEx.Client.MarketData` with `subscribe/3`, `snapshot/3`, `unsubscribe/2`, `tick_by_tick_subscribe/3`, and `tick_by_tick_unsubscribe/2`
- Stateless module following the Contracts pattern — builds proto structs and delegates to `Client.subscribe/3` and `Client.unsubscribe/2`
- Accepts both domain and proto contract types

## Test plan
- [x] 13 tests covering all 5 public functions
- [x] Verifies TickPrice, TickSize, TickSnapshotEnd, TickByTickData message delivery
- [x] Verifies error message routing to stream subscribers
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 408 tests, 0 failures