### PR TITLE
Add Client.HistoricalData thematic module

### DIFF
--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -176,10 +176,9 @@ defmodule IbEx.Client.Conversations do
       end_marker: Proto.HistoricalNewsEnd
     },
     Proto.HistoricalTicksRequest => %{
-      type: :bounded_stream,
+      type: :stream,
       correlation: :req_id,
       responses: [Proto.HistoricalTicks, Proto.HistoricalTicksBidAsk, Proto.HistoricalTicksLast],
-      end_marker: nil,
       cancel_request: Proto.CancelHistoricalTicks
     },
     Proto.FAReplace => %{

--- a/lib/ib_ex/client/historical_data.ex
+++ b/lib/ib_ex/client/historical_data.ex
@@ -1,0 +1,227 @@
+defmodule IbEx.Client.HistoricalData do
+  @moduledoc """
+  Thematic module for historical data operations.
+
+  Provides high-level functions for requesting historical bars, head timestamps,
+  histogram data, and historical ticks. This module is stateless -- it builds
+  proto request structs and delegates to `Client.request/3` or `Client.subscribe/3`.
+
+  ## Functions
+
+  * `request_bars/3` - Requests historical OHLCV bars for a contract
+    (bounded stream: accumulates HistoricalData responses, ends with HistoricalDataEnd).
+  * `head_timestamp/3` - Requests the earliest available data point for a contract
+    (single request/response).
+  * `histogram/3` - Requests histogram data for a contract
+    (single request/response).
+  * `request_ticks/3` - Subscribes to historical tick data for a contract
+    (stream of HistoricalTicks/HistoricalTicksBidAsk/HistoricalTicksLast batches,
+    each carrying an `is_done` flag indicating whether more data follows).
+  * `unsubscribe_ticks/2` - Cancels a historical ticks subscription.
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Mapper
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Types.Contract, as: DomainContract
+
+  @doc """
+  Requests historical OHLCV bars for the given contract.
+
+  Accepts domain contracts or proto contracts and sends a `HistoricalDataRequest`
+  through `Client.request/3`.
+
+  Returns `{:ok, [%Proto.HistoricalData{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:end_date_time` - End date/time string (default: `""`)
+  * `:duration` - Duration string, e.g. `"1 D"`, `"1 W"` (default: `"1 D"`)
+  * `:bar_size_setting` - Bar size, e.g. `"1 hour"`, `"1 day"` (default: `"1 day"`)
+  * `:what_to_show` - Data type: `"TRADES"`, `"MIDPOINT"`, `"BID"`, `"ASK"` (default: `"TRADES"`)
+  * `:use_rth` - Use regular trading hours only (default: `true`)
+  * `:format_date` - Date format: 1 for yyyyMMdd, 2 for epoch (default: `1`)
+  * `:keep_up_to_date` - Keep updating with new bars (default: `false`)
+  * `:chart_options` - Map of chart options (default: `%{}`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, bars_list} = HistoricalData.request_bars(client, contract)
+
+  """
+  @spec request_bars(pid(), struct(), keyword()) :: {:ok, list()} | {:error, any()}
+  def request_bars(client, contract, opts \\ [])
+
+  def request_bars(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_historical_data_request(proto_contract, opts)
+    Client.request(client, request, opts)
+  end
+
+  def request_bars(client, %DomainContract{} = contract, opts) do
+    request_bars(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Requests the earliest available data point for the given contract.
+
+  Accepts domain contracts or proto contracts and sends a `HeadTimestampRequest`
+  through `Client.request/3`.
+
+  Returns `{:ok, %Proto.HeadTimestamp{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:what_to_show` - Data type: `"TRADES"`, `"MIDPOINT"`, `"BID"`, `"ASK"` (default: `"TRADES"`)
+  * `:use_rth` - Use regular trading hours only (default: `true`)
+  * `:format_date` - Date format: 1 for yyyyMMdd, 2 for epoch (default: `1`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, %Proto.HeadTimestamp{}} = HistoricalData.head_timestamp(client, contract)
+
+  """
+  @spec head_timestamp(pid(), struct(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def head_timestamp(client, contract, opts \\ [])
+
+  def head_timestamp(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_head_timestamp_request(proto_contract, opts)
+    Client.request(client, request, opts)
+  end
+
+  def head_timestamp(client, %DomainContract{} = contract, opts) do
+    head_timestamp(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Requests histogram data for the given contract.
+
+  Accepts domain contracts or proto contracts and sends a `HistogramDataRequest`
+  through `Client.request/3`.
+
+  Returns `{:ok, %Proto.HistogramData{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:use_rth` - Use regular trading hours only (default: `true`)
+  * `:time_period` - Time period string, e.g. `"1 week"` (default: `"1 week"`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, %Proto.HistogramData{}} = HistoricalData.histogram(client, contract)
+
+  """
+  @spec histogram(pid(), struct(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def histogram(client, contract, opts \\ [])
+
+  def histogram(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_histogram_request(proto_contract, opts)
+    Client.request(client, request, opts)
+  end
+
+  def histogram(client, %DomainContract{} = contract, opts) do
+    histogram(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Subscribes to historical tick data for the given contract.
+
+  Accepts domain contracts or proto contracts and sends a `HistoricalTicksRequest`
+  through `Client.subscribe/3`. The caller receives `{:ib_ex, subscription_ref, msg}`
+  messages with `HistoricalTicks`, `HistoricalTicksBidAsk`, or `HistoricalTicksLast` protos.
+
+  Each response batch includes an `is_done` field -- when `true`, no more data follows
+  for the requested range.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:start_date_time` - Start date/time string (default: `""`)
+  * `:end_date_time` - End date/time string (default: `""`)
+  * `:number_of_ticks` - Number of ticks to request, max 1000 (default: `1000`)
+  * `:what_to_show` - Data type: `"TRADES"`, `"MIDPOINT"`, `"BID_ASK"` (default: `"TRADES"`)
+  * `:use_rth` - Use regular trading hours only (default: `true`)
+  * `:ignore_size` - Ignore size in tick data (default: `false`)
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      {:ok, ref} = HistoricalData.request_ticks(client, contract)
+
+  """
+  @spec request_ticks(pid(), struct(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def request_ticks(client, contract, opts \\ [])
+
+  def request_ticks(client, %Proto.Contract{} = proto_contract, opts) do
+    request = build_historical_ticks_request(proto_contract, opts)
+    Client.subscribe(client, request, opts)
+  end
+
+  def request_ticks(client, %DomainContract{} = contract, opts) do
+    request_ticks(client, Mapper.to_proto(contract), opts)
+  end
+
+  @doc """
+  Cancels a historical ticks subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelHistoricalTicks` message.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = HistoricalData.unsubscribe_ticks(client, subscription_ref)
+
+  """
+  @spec unsubscribe_ticks(pid(), reference()) :: :ok | {:error, :not_found}
+  def unsubscribe_ticks(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  defp build_historical_data_request(proto_contract, opts) do
+    %Proto.HistoricalDataRequest{
+      contract: proto_contract,
+      end_date_time: Keyword.get(opts, :end_date_time, ""),
+      duration: Keyword.get(opts, :duration, "1 D"),
+      bar_size_setting: Keyword.get(opts, :bar_size_setting, "1 day"),
+      what_to_show: Keyword.get(opts, :what_to_show, "TRADES"),
+      use_rth: Keyword.get(opts, :use_rth, true),
+      format_date: Keyword.get(opts, :format_date, 1),
+      keep_up_to_date: Keyword.get(opts, :keep_up_to_date, false),
+      chart_options: Keyword.get(opts, :chart_options, %{})
+    }
+  end
+
+  defp build_head_timestamp_request(proto_contract, opts) do
+    %Proto.HeadTimestampRequest{
+      contract: proto_contract,
+      what_to_show: Keyword.get(opts, :what_to_show, "TRADES"),
+      use_rth: Keyword.get(opts, :use_rth, true),
+      format_date: Keyword.get(opts, :format_date, 1)
+    }
+  end
+
+  defp build_histogram_request(proto_contract, opts) do
+    %Proto.HistogramDataRequest{
+      contract: proto_contract,
+      use_rth: Keyword.get(opts, :use_rth, true),
+      time_period: Keyword.get(opts, :time_period, "1 week")
+    }
+  end
+
+  defp build_historical_ticks_request(proto_contract, opts) do
+    %Proto.HistoricalTicksRequest{
+      contract: proto_contract,
+      start_date_time: Keyword.get(opts, :start_date_time, ""),
+      end_date_time: Keyword.get(opts, :end_date_time, ""),
+      number_of_ticks: Keyword.get(opts, :number_of_ticks, 1000),
+      what_to_show: Keyword.get(opts, :what_to_show, "TRADES"),
+      use_rth: Keyword.get(opts, :use_rth, true),
+      ignore_size: Keyword.get(opts, :ignore_size, false)
+    }
+  end
+end

--- a/test/ib_ex/client/historical_data_test.exs
+++ b/test/ib_ex/client/historical_data_test.exs
@@ -1,0 +1,425 @@
+defmodule IbEx.Client.HistoricalDataTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.HistoricalData
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Types.Contract, as: DomainContract
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @historical_data_wire_id 217
+  @historical_data_end_wire_id 308
+  @head_timestamp_wire_id 288
+  @histogram_data_wire_id 289
+  @historical_ticks_wire_id 296
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "request_bars/3" do
+    test "accumulates HistoricalData responses and returns {:ok, list} on HistoricalDataEnd" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.request_bars(client, contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      bar_1 = %Proto.HistoricalDataBar{date: "20240101", open: 150.0, high: 155.0, low: 149.0, close: 154.0}
+      bar_2 = %Proto.HistoricalDataBar{date: "20240102", open: 154.0, high: 158.0, low: 153.0, close: 157.0}
+
+      historical_data = %Proto.HistoricalData{
+        req_id: 1,
+        historical_data_bars: [bar_1, bar_2]
+      }
+
+      Client.process_message(client, wire_message(@historical_data_wire_id, historical_data))
+
+      end_marker = %Proto.HistoricalDataEnd{req_id: 1, start_date_str: "20240101", end_date_str: "20240102"}
+      Client.process_message(client, wire_message(@historical_data_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 1
+
+      [first] = results
+      assert %Proto.HistoricalData{req_id: 1} = first
+      assert length(first.historical_data_bars) == 2
+
+      [returned_bar_1, returned_bar_2] = first.historical_data_bars
+      assert returned_bar_1.date == "20240101"
+      assert returned_bar_1.open == 150.0
+      assert returned_bar_1.close == 154.0
+
+      assert returned_bar_2.date == "20240102"
+      assert returned_bar_2.open == 154.0
+      assert returned_bar_2.close == 157.0
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.request_bars(client, proto_contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      historical_data = %Proto.HistoricalData{
+        req_id: 1,
+        historical_data_bars: [%Proto.HistoricalDataBar{date: "20240101", open: 150.0, close: 154.0}]
+      }
+
+      Client.process_message(client, wire_message(@historical_data_wire_id, historical_data))
+
+      end_marker = %Proto.HistoricalDataEnd{req_id: 1}
+      Client.process_message(client, wire_message(@historical_data_end_wire_id, end_marker))
+
+      assert {:ok, [%Proto.HistoricalData{req_id: 1}]} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "INVALID", security_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.request_bars(client, contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 162,
+        error_msg: "Historical Market Data Service error message:No data of type TRADES"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 162
+      assert error.message == "Historical Market Data Service error message:No data of type TRADES"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      result =
+        try do
+          HistoricalData.request_bars(client, contract, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "head_timestamp/3" do
+    test "sends HeadTimestampRequest and returns {:ok, %HeadTimestamp{}} on response" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.head_timestamp(client, contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.HeadTimestamp{
+        req_id: 1,
+        head_timestamp: "1083297600"
+      }
+
+      Client.process_message(client, wire_message(@head_timestamp_wire_id, response))
+
+      assert {:ok, %Proto.HeadTimestamp{} = result} = Task.await(task, 5_000)
+      assert result.req_id == 1
+      assert result.head_timestamp == "1083297600"
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.head_timestamp(client, proto_contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.HeadTimestamp{req_id: 1, head_timestamp: "1083297600"}
+      Client.process_message(client, wire_message(@head_timestamp_wire_id, response))
+
+      assert {:ok, %Proto.HeadTimestamp{head_timestamp: "1083297600"}} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "INVALID", security_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.head_timestamp(client, contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      result =
+        try do
+          HistoricalData.head_timestamp(client, contract, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "histogram/3" do
+    test "sends HistogramDataRequest and returns {:ok, %HistogramData{}} on response" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.histogram(client, contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      entry_1 = %Proto.HistogramDataEntry{price: 150.0, size: "1000"}
+      entry_2 = %Proto.HistogramDataEntry{price: 151.5, size: "2500"}
+
+      response = %Proto.HistogramData{
+        req_id: 1,
+        histogram_data_entries: [entry_1, entry_2]
+      }
+
+      Client.process_message(client, wire_message(@histogram_data_wire_id, response))
+
+      assert {:ok, %Proto.HistogramData{} = result} = Task.await(task, 5_000)
+      assert result.req_id == 1
+      assert length(result.histogram_data_entries) == 2
+
+      [first_entry, second_entry] = result.histogram_data_entries
+      assert first_entry.price == 150.0
+      assert first_entry.size == "1000"
+      assert second_entry.price == 151.5
+      assert second_entry.size == "2500"
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.histogram(client, proto_contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.HistogramData{
+        req_id: 1,
+        histogram_data_entries: [%Proto.HistogramDataEntry{price: 150.0, size: "1000"}]
+      }
+
+      Client.process_message(client, wire_message(@histogram_data_wire_id, response))
+
+      assert {:ok, %Proto.HistogramData{req_id: 1}} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "INVALID", security_type: "STK", currency: "USD"}
+
+      task =
+        Task.async(fn ->
+          HistoricalData.histogram(client, contract, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      result =
+        try do
+          HistoricalData.histogram(client, contract, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "request_ticks/3" do
+    test "subscribes to historical ticks and receives HistoricalTicks messages" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = HistoricalData.request_ticks(client, contract)
+      assert is_reference(ref)
+
+      tick_1 = %Proto.HistoricalTick{time: 1_700_000_000, price: 150.25, size: "100"}
+      tick_2 = %Proto.HistoricalTick{time: 1_700_000_001, price: 150.50, size: "200"}
+
+      response = %Proto.HistoricalTicks{
+        req_id: 1,
+        historical_ticks: [tick_1, tick_2],
+        is_done: false
+      }
+
+      Client.process_message(client, wire_message(@historical_ticks_wire_id, response))
+
+      assert_receive {:ib_ex, ^ref, %Proto.HistoricalTicks{} = received}, 1_000
+      assert received.req_id == 1
+      assert length(received.historical_ticks) == 2
+      assert received.is_done == false
+    end
+
+    test "receives final batch with is_done flag set to true" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = HistoricalData.request_ticks(client, contract)
+
+      response = %Proto.HistoricalTicks{
+        req_id: 1,
+        historical_ticks: [%Proto.HistoricalTick{time: 1_700_000_000, price: 150.25, size: "100"}],
+        is_done: true
+      }
+
+      Client.process_message(client, wire_message(@historical_ticks_wire_id, response))
+
+      assert_receive {:ib_ex, ^ref, %Proto.HistoricalTicks{is_done: true}}, 1_000
+    end
+
+    test "accepts proto contracts directly" do
+      client = start_client()
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+
+      {:ok, ref} = HistoricalData.request_ticks(client, proto_contract)
+      assert is_reference(ref)
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+      contract = %DomainContract{symbol: "INVALID", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = HistoricalData.request_ticks(client, contract)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+  end
+
+  describe "unsubscribe_ticks/2" do
+    test "cancels an active historical ticks subscription" do
+      client = start_client()
+      contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+
+      {:ok, ref} = HistoricalData.request_ticks(client, contract)
+      assert :ok = HistoricalData.unsubscribe_ticks(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = HistoricalData.unsubscribe_ticks(client, fake_ref)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `IbEx.Client.HistoricalData` with `request_bars/3`, `head_timestamp/3`, `histogram/3`, `request_ticks/3`, and `unsubscribe_ticks/2`
- Reclassifies `HistoricalTicksRequest` from `:bounded_stream` (end_marker: nil) to `:stream` — canonical TWS API treats it as a cancelable stream with server-side pagination and an `is_done` flag on each batch
- Follows the Contracts/MarketData module pattern: stateless, builds proto structs, delegates to `Client.request/3` or `Client.subscribe/3`

## Test plan
- [x] 18 tests covering all 5 public functions
- [x] Verifies bounded stream accumulation (request_bars), request/response (head_timestamp, histogram), and stream delivery (request_ticks)
- [x] Verifies `is_done` flag propagation on historical tick batches
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 426 tests, 0 failures