### PR TITLE
Add Client.System thematic module

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -69,6 +69,10 @@ defmodule IbEx.Client do
     GenServer.call(pid, {:unsubscribe, subscription_ref})
   end
 
+  def command(pid, proto_msg) do
+    GenServer.call(pid, {:command, proto_msg})
+  end
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts)
   end
@@ -205,6 +209,11 @@ defmodule IbEx.Client do
       {:error, :missing_subscription} ->
         {:reply, {:error, :not_found}, state}
     end
+  end
+
+  def handle_call({:command, proto_msg}, _from, state) do
+    send_to_tws(state, proto_msg)
+    {:reply, :ok, state}
   end
 
   def handle_info({:request_timeout, key}, state) do

--- a/lib/ib_ex/client/system.ex
+++ b/lib/ib_ex/client/system.ex
@@ -1,0 +1,141 @@
+defmodule IbEx.Client.System do
+  @moduledoc """
+  Thematic module for system-level operations.
+
+  Provides high-level functions for querying server time, setting log levels,
+  retrieving configuration, and fetching user information. This module is
+  stateless -- it builds proto request structs and delegates to `Client.request/3`
+  or `Client.command/2`.
+
+  ## Functions
+
+  * `current_time/2` - Requests the server's current time in seconds
+    (single request/response, global correlation).
+  * `current_time_millis/2` - Requests the server's current time in milliseconds
+    (single request/response, global correlation).
+  * `set_log_level/2` - Sets the TWS server log verbosity level
+    (fire-and-forget command, no response expected).
+  * `config/2` - Requests the server configuration
+    (single request/response, req_id correlation).
+  * `user_info/2` - Requests information about the authenticated user
+    (single request/response, req_id correlation).
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  @doc """
+  Requests the server's current time in seconds (Unix epoch).
+
+  Sends a `CurrentTimeRequest` through `Client.request/3` using global correlation.
+
+  Returns `{:ok, %Proto.CurrentTime{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.CurrentTime{current_time: unix_seconds}} = System.current_time(client)
+
+  """
+  @spec current_time(pid(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def current_time(client, opts \\ []) do
+    request = %Proto.CurrentTimeRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests the server's current time in milliseconds (Unix epoch).
+
+  Sends a `CurrentTimeInMillisRequest` through `Client.request/3` using global correlation.
+
+  Returns `{:ok, %Proto.CurrentTimeInMillis{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.CurrentTimeInMillis{current_time_in_millis: millis}} = System.current_time_millis(client)
+
+  """
+  @spec current_time_millis(pid(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def current_time_millis(client, opts \\ []) do
+    request = %Proto.CurrentTimeInMillisRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Sets the TWS server log verbosity level.
+
+  Sends a `SetServerLogLevelRequest` as a fire-and-forget command through
+  `Client.command/2`. No response is expected from the server.
+
+  ## Log Levels
+
+  * `1` - System
+  * `2` - Error
+  * `3` - Warning
+  * `4` - Information
+  * `5` - Detail
+
+  Returns `:ok`.
+
+  ## Examples
+
+      :ok = System.set_log_level(client, 5)
+
+  """
+  @spec set_log_level(pid(), integer()) :: :ok
+  def set_log_level(client, log_level) when is_integer(log_level) do
+    request = %Proto.SetServerLogLevelRequest{log_level: log_level}
+    Client.command(client, request)
+  end
+
+  @doc """
+  Requests the server configuration.
+
+  Sends a `ConfigRequest` through `Client.request/3` using req_id correlation.
+
+  Returns `{:ok, %Proto.ConfigResponse{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.ConfigResponse{}} = System.config(client)
+
+  """
+  @spec config(pid(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def config(client, opts \\ []) do
+    request = %Proto.ConfigRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests information about the authenticated user.
+
+  Sends a `UserInfoRequest` through `Client.request/3` using req_id correlation.
+
+  Returns `{:ok, %Proto.UserInfo{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.UserInfo{white_branding_id: branding_id}} = System.user_info(client)
+
+  """
+  @spec user_info(pid(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def user_info(client, opts \\ []) do
+    request = %Proto.UserInfoRequest{}
+    Client.request(client, request, opts)
+  end
+end

--- a/test/ib_ex/client/system_test.exs
+++ b/test/ib_ex/client/system_test.exs
@@ -1,0 +1,247 @@
+defmodule IbEx.Client.SystemTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.System
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @current_time_wire_id 249
+  @current_time_in_millis_wire_id 309
+  @user_info_wire_id 307
+  @config_response_wire_id 310
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "current_time/2" do
+    test "sends CurrentTimeRequest and returns {:ok, %CurrentTime{}} on response" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          System.current_time(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.CurrentTime{current_time: 1_700_000_000}
+      Client.process_message(client, wire_message(@current_time_wire_id, response))
+
+      assert {:ok, %Proto.CurrentTime{} = result} = Task.await(task, 5_000)
+      assert result.current_time == 1_700_000_000
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          System.current_time(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "current_time_millis/2" do
+    test "sends CurrentTimeInMillisRequest and returns {:ok, %CurrentTimeInMillis{}} on response" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          System.current_time_millis(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.CurrentTimeInMillis{current_time_in_millis: 1_700_000_000_123}
+      Client.process_message(client, wire_message(@current_time_in_millis_wire_id, response))
+
+      assert {:ok, %Proto.CurrentTimeInMillis{} = result} = Task.await(task, 5_000)
+      assert result.current_time_in_millis == 1_700_000_000_123
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          System.current_time_millis(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "set_log_level/2" do
+    test "sends SetServerLogLevelRequest and returns :ok" do
+      client = start_client()
+
+      assert :ok = System.set_log_level(client, 5)
+    end
+
+    test "accepts all valid log levels" do
+      client = start_client()
+
+      for level <- [1, 2, 3, 4, 5] do
+        assert :ok = System.set_log_level(client, level)
+      end
+    end
+  end
+
+  describe "config/2" do
+    test "sends ConfigRequest and returns {:ok, %ConfigResponse{}} on response" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          System.config(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.ConfigResponse{
+        req_id: 1,
+        messages: [],
+        api: %Proto.ApiConfig{},
+        orders: %Proto.OrdersConfig{}
+      }
+
+      Client.process_message(client, wire_message(@config_response_wire_id, response))
+
+      assert {:ok, %Proto.ConfigResponse{} = result} = Task.await(task, 5_000)
+      assert result.req_id == 1
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          System.config(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 321,
+        error_msg: "Error validating request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 321
+      assert error.message == "Error validating request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          System.config(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "user_info/2" do
+    test "sends UserInfoRequest and returns {:ok, %UserInfo{}} on response" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          System.user_info(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.UserInfo{
+        req_id: 1,
+        white_branding_id: "branding-123"
+      }
+
+      Client.process_message(client, wire_message(@user_info_wire_id, response))
+
+      assert {:ok, %Proto.UserInfo{} = result} = Task.await(task, 5_000)
+      assert result.req_id == 1
+      assert result.white_branding_id == "branding-123"
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          System.user_info(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "User info not available"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "User info not available"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          System.user_info(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `IbEx.Client.System` thematic module with five functions: `current_time/2`, `current_time_millis/2`, `set_log_level/2`, `config/2`, and `user_info/2`
- Adds `Client.command/2` for fire-and-forget messages (used by `set_log_level`)
- 12 new tests covering all functions (success, timeout, error handling)

## Test plan

- [x] All 438 tests pass (12 new + 426 existing)
- [ ] Verify against live TWS/Gateway connection