### PR TITLE
Add Client.Orders thematic module

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -190,7 +190,8 @@ defmodule IbEx.Client do
   def handle_call({:subscribe, subscriber, %message_type{} = proto_msg, _opts}, _from, state) do
     case Conversations.register_stream(state.subscriptions_table_ref, message_type, subscriber) do
       {:ok, req_id, subscription_ref} ->
-        send_to_tws(state, %{proto_msg | req_id: req_id})
+        proto_msg = set_correlation_id(message_type, proto_msg, req_id)
+        send_to_tws(state, proto_msg)
         {:reply, {:ok, subscription_ref}, state}
 
       :error ->
@@ -277,14 +278,26 @@ defmodule IbEx.Client do
 
     case Conversations.cancel_request_for(request_module) do
       {:ok, cancel_module} ->
-        {:request_id, req_id} = key
-        send_to_tws(state, struct!(cancel_module, req_id: req_id))
+        case key do
+          {:request_id, req_id} ->
+            send_to_tws(state, struct!(cancel_module, req_id: req_id))
+
+          {:order_id, order_id} ->
+            send_to_tws(state, struct!(cancel_module, order_id: order_id))
+        end
 
       :error ->
         :ok
     end
 
     Subscriptions.remove_subscription(table_ref, key)
+  end
+
+  defp set_correlation_id(message_type, proto_msg, id) do
+    case Conversations.conversation_for(message_type) do
+      {:ok, %{correlation: :order_id}} -> %{proto_msg | order_id: id}
+      _ -> %{proto_msg | req_id: id}
+    end
   end
 
   defp dispatch_message(%Types.Error{id: id} = error, table_ref) when id > 0 do
@@ -304,8 +317,14 @@ defmodule IbEx.Client do
 
   defp dispatch_message(%module{} = msg, table_ref) do
     case Map.get(msg, :req_id) do
-      nil -> dispatch_by_module(module, msg, table_ref)
-      req_id -> dispatch_by_req_id({:request_id, req_id}, msg, module, table_ref)
+      nil ->
+        case Map.get(msg, :order_id) do
+          nil -> dispatch_by_module(module, msg, table_ref)
+          order_id -> dispatch_by_order_id({:order_id, order_id}, msg, module, table_ref)
+        end
+
+      req_id ->
+        dispatch_by_req_id({:request_id, req_id}, msg, module, table_ref)
     end
   end
 
@@ -321,6 +340,16 @@ defmodule IbEx.Client do
 
       _ ->
         :ok
+    end
+  end
+
+  defp dispatch_by_order_id(key, msg, module, table_ref) do
+    case Subscriptions.lookup(table_ref, key) do
+      {:ok, %{type: :stream, subscriber: subscriber, subscription_ref: ref}} ->
+        send(subscriber, {:ib_ex, ref, msg})
+
+      _ ->
+        dispatch_by_module(module, msg, table_ref)
     end
   end
 

--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -527,9 +527,15 @@ defmodule IbEx.Client.Conversations do
   @spec register_stream(reference(), module(), pid()) :: {:ok, non_neg_integer(), reference()} | :error
   def register_stream(table_ref, request_module, subscriber) do
     case conversation_for(request_module) do
-      {:ok, %{type: :stream}} ->
+      {:ok, %{type: :stream, correlation: correlation}} ->
         req_id = Subscriptions.allocate_request_id(table_ref)
-        key = {:request_id, req_id}
+
+        key =
+          case correlation do
+            :order_id -> {:order_id, req_id}
+            _ -> {:request_id, req_id}
+          end
+
         subscription_ref = make_ref()
         monitor_ref = Process.monitor(subscriber)
 

--- a/lib/ib_ex/client/orders.ex
+++ b/lib/ib_ex/client/orders.ex
@@ -1,0 +1,215 @@
+defmodule IbEx.Client.Orders do
+  @moduledoc """
+  Thematic module for order operations.
+
+  Provides high-level functions for querying open orders, placing and cancelling
+  orders, and retrieving completed orders. This module is stateless -- it builds
+  proto request structs and delegates to `Client.request/3`, `Client.subscribe/3`,
+  or `Client.command/2`.
+
+  ## Functions
+
+  * `open_orders/2` - Requests open orders for this client
+    (bounded stream: accumulates OpenOrder responses, ends with OpenOrdersEnd, global correlation).
+  * `all_open_orders/2` - Requests all open orders across all clients
+    (bounded stream: accumulates OpenOrder responses, ends with OpenOrdersEnd, global correlation).
+  * `completed_orders/2` - Requests completed orders
+    (bounded stream: accumulates CompletedOrder responses, ends with CompletedOrdersEnd, global correlation).
+  * `place/4` - Places an order for a contract
+    (stream subscription with order_id correlation, receives OpenOrder, OrderStatus, etc.).
+  * `cancel/3` - Cancels a specific order by order_id
+    (fire-and-forget command).
+  * `global_cancel/1` - Cancels all open orders
+    (fire-and-forget command).
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Mapper
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Types.Contract, as: DomainContract
+  alias IbEx.Client.Types.Order, as: DomainOrder
+
+  @doc """
+  Requests open orders for this API client.
+
+  Sends an `OpenOrdersRequest` through `Client.request/3` using global correlation.
+  The response is a bounded stream that accumulates `OpenOrder` protos and ends
+  with an `OpenOrdersEnd` marker.
+
+  Returns `{:ok, [%Proto.OpenOrder{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, orders} = Orders.open_orders(client)
+
+  """
+  @spec open_orders(pid(), keyword()) :: {:ok, list()} | {:error, any()}
+  def open_orders(client, opts \\ []) do
+    request = %Proto.OpenOrdersRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests all open orders across all API clients.
+
+  Sends an `AllOpenOrdersRequest` through `Client.request/3` using global correlation.
+  The response is a bounded stream that accumulates `OpenOrder` protos and ends
+  with an `OpenOrdersEnd` marker.
+
+  Returns `{:ok, [%Proto.OpenOrder{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, orders} = Orders.all_open_orders(client)
+
+  """
+  @spec all_open_orders(pid(), keyword()) :: {:ok, list()} | {:error, any()}
+  def all_open_orders(client, opts \\ []) do
+    request = %Proto.AllOpenOrdersRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests completed orders.
+
+  Sends a `CompletedOrdersRequest` through `Client.request/3` using global correlation.
+  The response is a bounded stream that accumulates `CompletedOrder` protos and ends
+  with a `CompletedOrdersEnd` marker.
+
+  Returns `{:ok, [%Proto.CompletedOrder{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:api_only` - If `true`, only return orders placed through the API (default: `false`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, orders} = Orders.completed_orders(client)
+      {:ok, orders} = Orders.completed_orders(client, api_only: true)
+
+  """
+  @spec completed_orders(pid(), keyword()) :: {:ok, list()} | {:error, any()}
+  def completed_orders(client, opts \\ []) do
+    request = %Proto.CompletedOrdersRequest{
+      api_only: Keyword.get(opts, :api_only, false)
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Places an order for the given contract.
+
+  Accepts domain contracts/orders or proto contracts/orders, builds a `PlaceOrderRequest`,
+  and sends it through `Client.subscribe/3` using order_id correlation.
+
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with OpenOrder,
+  OrderStatus, OrderBound, CommissionAndFeesReport, and DeltaNeutralContract protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * Currently unused, reserved for future options.
+
+  ## Examples
+
+      contract = %IbEx.Client.Types.Contract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      order = %IbEx.Client.Types.Order{action: "BUY", total_quantity: 100, order_type: "LMT", limit_price: 150.0}
+      {:ok, ref} = Orders.place(client, contract, order)
+
+  """
+  @spec place(pid(), struct(), struct(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def place(client, contract, order, opts \\ [])
+
+  def place(client, %Proto.Contract{} = proto_contract, %Proto.Order{} = proto_order, opts) do
+    request = %Proto.PlaceOrderRequest{
+      contract: proto_contract,
+      order: proto_order
+    }
+
+    Client.subscribe(client, request, opts)
+  end
+
+  def place(client, %DomainContract{} = contract, %Proto.Order{} = proto_order, opts) do
+    place(client, Mapper.to_proto(contract), proto_order, opts)
+  end
+
+  def place(client, %Proto.Contract{} = proto_contract, %DomainOrder{} = order, opts) do
+    place(client, proto_contract, Mapper.to_proto(order), opts)
+  end
+
+  def place(client, %DomainContract{} = contract, %DomainOrder{} = order, opts) do
+    place(client, Mapper.to_proto(contract), Mapper.to_proto(order), opts)
+  end
+
+  @doc """
+  Cancels a specific order by order_id.
+
+  Builds a `CancelOrderRequest` and sends it as a fire-and-forget command
+  through `Client.command/2`. Any resulting status updates (e.g. OrderStatus
+  with "Cancelled") are delivered through the order's existing PlaceOrder
+  lifecycle stream.
+
+  Returns `:ok`.
+
+  ## Options
+
+  * `:manual_order_cancel_time` - Manual order cancel time string (default: `""`)
+  * `:ext_operator` - External operator string (default: `""`)
+  * `:manual_order_indicator` - Manual order indicator integer (default: `0`)
+
+  ## Examples
+
+      :ok = Orders.cancel(client, 42)
+      :ok = Orders.cancel(client, 42, manual_order_cancel_time: "20240101 12:00:00")
+
+  """
+  @spec cancel(pid(), integer(), keyword()) :: :ok
+  def cancel(client, order_id, opts \\ []) when is_integer(order_id) do
+    order_cancel = %Proto.OrderCancel{
+      manual_order_cancel_time: Keyword.get(opts, :manual_order_cancel_time, ""),
+      ext_operator: Keyword.get(opts, :ext_operator, ""),
+      manual_order_indicator: Keyword.get(opts, :manual_order_indicator, 0)
+    }
+
+    request = %Proto.CancelOrderRequest{
+      order_id: order_id,
+      order_cancel: order_cancel
+    }
+
+    Client.command(client, request)
+  end
+
+  @doc """
+  Cancels all open orders globally.
+
+  Sends a `GlobalCancelRequest` as a fire-and-forget command through
+  `Client.command/2`. No response is expected from the server directly;
+  cancellation status updates arrive through individual order lifecycle streams.
+
+  Returns `:ok`.
+
+  ## Examples
+
+      :ok = Orders.global_cancel(client)
+
+  """
+  @spec global_cancel(pid()) :: :ok
+  def global_cancel(client) do
+    request = %Proto.GlobalCancelRequest{}
+    Client.command(client, request)
+  end
+end

--- a/test/ib_ex/client/orders_test.exs
+++ b/test/ib_ex/client/orders_test.exs
@@ -1,0 +1,412 @@
+defmodule IbEx.Client.OrdersTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.Orders
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Types.Contract, as: DomainContract
+  alias IbEx.Client.Types.Order, as: DomainOrder
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @open_order_wire_id 205
+  @open_orders_end_wire_id 253
+  @completed_order_wire_id 301
+  @completed_orders_end_wire_id 302
+  @order_status_wire_id 203
+  @order_bound_wire_id 300
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "open_orders/2" do
+    test "accumulates OpenOrder responses and returns {:ok, list} on OpenOrdersEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.open_orders(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      order_1 = %Proto.OpenOrder{
+        order_id: 1,
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        order: %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0},
+        order_state: %Proto.OrderState{status: "PreSubmitted"}
+      }
+
+      order_2 = %Proto.OpenOrder{
+        order_id: 2,
+        contract: %Proto.Contract{symbol: "MSFT", sec_type: "STK", currency: "USD"},
+        order: %Proto.Order{action: "SELL", total_quantity: "50", order_type: "MKT"},
+        order_state: %Proto.OrderState{status: "Submitted"}
+      }
+
+      Client.process_message(client, wire_message(@open_order_wire_id, order_1))
+      Client.process_message(client, wire_message(@open_order_wire_id, order_2))
+
+      end_marker = %Proto.OpenOrdersEnd{}
+      Client.process_message(client, wire_message(@open_orders_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.OpenOrder{order_id: 1} = first
+      assert first.contract.symbol == "AAPL"
+      assert first.order.action == "BUY"
+      assert first.order.total_quantity == "100"
+      assert first.order_state.status == "PreSubmitted"
+
+      assert %Proto.OpenOrder{order_id: 2} = second
+      assert second.contract.symbol == "MSFT"
+      assert second.order.action == "SELL"
+      assert second.order_state.status == "Submitted"
+    end
+
+    test "returns {:ok, []} when no open orders exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.open_orders(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.OpenOrdersEnd{}
+      Client.process_message(client, wire_message(@open_orders_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Orders.open_orders(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "all_open_orders/2" do
+    test "accumulates OpenOrder responses and returns {:ok, list} on OpenOrdersEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.all_open_orders(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      order = %Proto.OpenOrder{
+        order_id: 10,
+        contract: %Proto.Contract{symbol: "GOOG", sec_type: "STK", currency: "USD"},
+        order: %Proto.Order{action: "BUY", total_quantity: "25", order_type: "LMT", lmt_price: 140.0},
+        order_state: %Proto.OrderState{status: "PreSubmitted"}
+      }
+
+      Client.process_message(client, wire_message(@open_order_wire_id, order))
+
+      end_marker = %Proto.OpenOrdersEnd{}
+      Client.process_message(client, wire_message(@open_orders_end_wire_id, end_marker))
+
+      assert {:ok, [%Proto.OpenOrder{} = result]} = Task.await(task, 5_000)
+      assert result.order_id == 10
+      assert result.contract.symbol == "GOOG"
+      assert result.order.total_quantity == "25"
+      assert result.order.lmt_price == 140.0
+    end
+
+    test "returns {:ok, []} when no open orders exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.all_open_orders(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.OpenOrdersEnd{}
+      Client.process_message(client, wire_message(@open_orders_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Orders.all_open_orders(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "completed_orders/2" do
+    test "accumulates CompletedOrder responses and returns {:ok, list} on CompletedOrdersEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.completed_orders(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      completed_1 = %Proto.CompletedOrder{
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        order: %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 145.0},
+        order_state: %Proto.OrderState{status: "Filled"}
+      }
+
+      completed_2 = %Proto.CompletedOrder{
+        contract: %Proto.Contract{symbol: "TSLA", sec_type: "STK", currency: "USD"},
+        order: %Proto.Order{action: "SELL", total_quantity: "50", order_type: "MKT"},
+        order_state: %Proto.OrderState{status: "Filled"}
+      }
+
+      Client.process_message(client, wire_message(@completed_order_wire_id, completed_1))
+      Client.process_message(client, wire_message(@completed_order_wire_id, completed_2))
+
+      end_marker = %Proto.CompletedOrdersEnd{}
+      Client.process_message(client, wire_message(@completed_orders_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.CompletedOrder{} = first
+      assert first.contract.symbol == "AAPL"
+      assert first.order.action == "BUY"
+      assert first.order.lmt_price == 145.0
+      assert first.order_state.status == "Filled"
+
+      assert %Proto.CompletedOrder{} = second
+      assert second.contract.symbol == "TSLA"
+      assert second.order.action == "SELL"
+      assert second.order_state.status == "Filled"
+    end
+
+    test "returns {:ok, []} when no completed orders exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.completed_orders(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.CompletedOrdersEnd{}
+      Client.process_message(client, wire_message(@completed_orders_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "passes api_only option to the request" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Orders.completed_orders(client, api_only: true, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.CompletedOrdersEnd{}
+      Client.process_message(client, wire_message(@completed_orders_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Orders.completed_orders(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "place/4" do
+    test "subscribes to order lifecycle and receives OrderStatus messages" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+      proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
+
+      {:ok, ref} = Orders.place(client, proto_contract, proto_order)
+      assert is_reference(ref)
+
+      # The allocated order_id should be 1 (first allocation)
+      order_status = %Proto.OrderStatus{
+        order_id: 1,
+        status: "PreSubmitted",
+        filled: "0",
+        remaining: "100",
+        avg_fill_price: 0.0,
+        perm_id: 12345,
+        parent_id: 0,
+        last_fill_price: 0.0,
+        client_id: 0,
+        why_held: "",
+        mkt_cap_price: 0.0
+      }
+
+      Client.process_message(client, wire_message(@order_status_wire_id, order_status))
+
+      assert_receive {:ib_ex, ^ref, %Proto.OrderStatus{} = received}, 1_000
+      assert received.order_id == 1
+      assert received.status == "PreSubmitted"
+      assert received.filled == "0"
+      assert received.remaining == "100"
+      assert received.perm_id == 12345
+    end
+
+    test "receives OpenOrder messages through the subscription" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+      proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
+
+      {:ok, ref} = Orders.place(client, proto_contract, proto_order)
+
+      open_order = %Proto.OpenOrder{
+        order_id: 1,
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        order: %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0},
+        order_state: %Proto.OrderState{status: "PreSubmitted"}
+      }
+
+      Client.process_message(client, wire_message(@open_order_wire_id, open_order))
+
+      assert_receive {:ib_ex, ^ref, %Proto.OpenOrder{} = received}, 1_000
+      assert received.order_id == 1
+      assert received.contract.symbol == "AAPL"
+      assert received.order.action == "BUY"
+    end
+
+    test "receives OrderBound messages through the subscription" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+      proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
+
+      {:ok, ref} = Orders.place(client, proto_contract, proto_order)
+
+      order_bound = %Proto.OrderBound{
+        order_id: 1,
+        client_id: 0,
+        perm_id: 98765
+      }
+
+      Client.process_message(client, wire_message(@order_bound_wire_id, order_bound))
+
+      assert_receive {:ib_ex, ^ref, %Proto.OrderBound{} = received}, 1_000
+      assert received.order_id == 1
+      assert received.perm_id == 98765
+    end
+
+    test "accepts domain contracts and proto orders" do
+      client = start_client()
+
+      domain_contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
+
+      {:ok, ref} = Orders.place(client, domain_contract, proto_order)
+      assert is_reference(ref)
+    end
+
+    test "accepts proto contracts and domain orders" do
+      client = start_client()
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+      domain_order = DomainOrder.new(%{action: "BUY", total_quantity: 100, order_type: "LMT", limit_price: 150.0})
+
+      {:ok, ref} = Orders.place(client, proto_contract, domain_order)
+      assert is_reference(ref)
+    end
+
+    test "accepts domain contracts and domain orders" do
+      client = start_client()
+
+      domain_contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
+      domain_order = DomainOrder.new(%{action: "BUY", total_quantity: 100, order_type: "LMT", limit_price: 150.0})
+
+      {:ok, ref} = Orders.place(client, domain_contract, domain_order)
+      assert is_reference(ref)
+    end
+  end
+
+  describe "cancel/3" do
+    test "sends CancelOrderRequest and returns :ok" do
+      client = start_client()
+
+      assert :ok = Orders.cancel(client, 42)
+    end
+
+    test "accepts options for order cancel parameters" do
+      client = start_client()
+
+      assert :ok = Orders.cancel(client, 42, manual_order_cancel_time: "20240101 12:00:00", ext_operator: "ext_op")
+    end
+
+    test "sends cancel for different order IDs" do
+      client = start_client()
+
+      for order_id <- [1, 10, 100, 9999] do
+        assert :ok = Orders.cancel(client, order_id)
+      end
+    end
+  end
+
+  describe "global_cancel/1" do
+    test "sends GlobalCancelRequest and returns :ok" do
+      client = start_client()
+
+      assert :ok = Orders.global_cancel(client)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `IbEx.Client.Orders` thematic module with `open_orders/2`, `all_open_orders/2`, `completed_orders/2`, `place/4`, `cancel/3`, and `global_cancel/1`
- Adds `order_id` correlation support in `Client` dispatch and `Conversations.register_stream/3`
- `place/4` streams order lifecycle messages (`OpenOrder`, `OrderStatus`, `OrderBound`) via subscription
- `cancel/3` and `global_cancel/1` are fire-and-forget commands
- 20 new tests covering all functions

## Test plan

- [x] All 472 tests pass (20 new + 452 existing)
- [ ] Verify against live TWS/Gateway connection