### PR TITLE
Add Client.Scanner thematic module

### DIFF
--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -136,10 +136,9 @@ defmodule IbEx.Client.Conversations do
       cancel_request: Proto.CancelHistoricalData
     },
     Proto.ScannerSubscriptionRequest => %{
-      type: :bounded_stream,
+      type: :stream,
       correlation: :req_id,
       responses: [Proto.ScannerData],
-      end_marker: nil,
       cancel_request: Proto.CancelScannerSubscription
     },
     Proto.AccountSummaryRequest => %{

--- a/lib/ib_ex/client/scanner.ex
+++ b/lib/ib_ex/client/scanner.ex
@@ -1,0 +1,95 @@
+defmodule IbEx.Client.Scanner do
+  @moduledoc """
+  Thematic module for market scanner operations.
+
+  Provides high-level functions for subscribing to scanner data streams,
+  cancelling scanner subscriptions, and requesting scanner parameters.
+  This module is stateless -- it builds proto request structs and delegates
+  to `Client.subscribe/3`, `Client.unsubscribe/2`, and `Client.request/3`.
+
+  ## Functions
+
+  * `subscribe/3` - Subscribes to a scanner data stream for the given subscription criteria
+    (ScannerData).
+  * `unsubscribe/2` - Cancels a scanner subscription.
+  * `parameters/2` - Requests the XML document describing available scanner parameters.
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  @doc """
+  Subscribes to a scanner data stream for the given subscription criteria.
+
+  Builds a `ScannerSubscriptionRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with
+  ScannerData protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * Currently unused, reserved for future options.
+
+  ## Examples
+
+      scanner_sub = %IbEx.Client.Proto.Protobuf.ScannerSubscription{
+        instrument: "STK",
+        location_code: "STK.US.MAJOR",
+        scan_code: "TOP_PERC_GAIN",
+        number_of_rows: 10
+      }
+      {:ok, ref} = Scanner.subscribe(client, scanner_sub)
+
+  """
+  @spec subscribe(pid(), struct(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def subscribe(client, scanner_subscription, opts \\ [])
+
+  def subscribe(client, %Proto.ScannerSubscription{} = scanner_subscription, opts) do
+    request = %Proto.ScannerSubscriptionRequest{scanner_subscription: scanner_subscription}
+    Client.subscribe(client, request, opts)
+  end
+
+  @doc """
+  Cancels a scanner subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelScannerSubscription`
+  message and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = Scanner.unsubscribe(client, subscription_ref)
+
+  """
+  @spec unsubscribe(pid(), reference()) :: :ok | {:error, :not_found}
+  def unsubscribe(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  @doc """
+  Requests the XML document describing available scanner parameters.
+
+  Sends a `ScannerParametersRequest` through `Client.request/3` using global
+  correlation (no req_id). Returns the XML string containing all available
+  scanner parameters, instruments, locations, and scan codes.
+
+  Returns `{:ok, %Proto.ScannerParameters{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.ScannerParameters{} = result} = Scanner.parameters(client)
+      result.xml
+
+  """
+  @spec parameters(pid(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def parameters(client, opts \\ []) do
+    request = %Proto.ScannerParametersRequest{}
+    Client.request(client, request, opts)
+  end
+end

--- a/test/ib_ex/client/scanner_test.exs
+++ b/test/ib_ex/client/scanner_test.exs
@@ -1,0 +1,195 @@
+defmodule IbEx.Client.ScannerTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.Scanner
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @scanner_data_wire_id 220
+  @scanner_parameters_wire_id 219
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "subscribe/3" do
+    test "subscribes to scanner data and receives ScannerData messages" do
+      client = start_client()
+
+      scanner_sub = %Proto.ScannerSubscription{
+        instrument: "STK",
+        location_code: "STK.US.MAJOR",
+        scan_code: "TOP_PERC_GAIN",
+        number_of_rows: 10
+      }
+
+      {:ok, ref} = Scanner.subscribe(client, scanner_sub)
+      assert is_reference(ref)
+
+      element = %Proto.ScannerDataElement{
+        rank: 0,
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        market_name: "NMS",
+        distance: "",
+        benchmark: "",
+        projection: "",
+        combo_key: ""
+      }
+
+      scanner_data = %Proto.ScannerData{req_id: 1, scanner_data_element: [element]}
+      Client.process_message(client, wire_message(@scanner_data_wire_id, scanner_data))
+
+      assert_receive {:ib_ex, ^ref, %Proto.ScannerData{} = received}, 1_000
+      assert received.req_id == 1
+      assert length(received.scanner_data_element) == 1
+
+      [first] = received.scanner_data_element
+      assert first.rank == 0
+      assert first.contract.symbol == "AAPL"
+      assert first.contract.sec_type == "STK"
+      assert first.contract.currency == "USD"
+      assert first.market_name == "NMS"
+    end
+
+    test "receives multiple ScannerData messages on the same subscription" do
+      client = start_client()
+
+      scanner_sub = %Proto.ScannerSubscription{
+        instrument: "STK",
+        location_code: "STK.US.MAJOR",
+        scan_code: "TOP_PERC_GAIN",
+        number_of_rows: 5
+      }
+
+      {:ok, ref} = Scanner.subscribe(client, scanner_sub)
+
+      element_1 = %Proto.ScannerDataElement{
+        rank: 0,
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        market_name: "NMS"
+      }
+
+      element_2 = %Proto.ScannerDataElement{
+        rank: 0,
+        contract: %Proto.Contract{symbol: "TSLA", sec_type: "STK", currency: "USD"},
+        market_name: "NMS"
+      }
+
+      data_1 = %Proto.ScannerData{req_id: 1, scanner_data_element: [element_1]}
+      data_2 = %Proto.ScannerData{req_id: 1, scanner_data_element: [element_2]}
+
+      Client.process_message(client, wire_message(@scanner_data_wire_id, data_1))
+      Client.process_message(client, wire_message(@scanner_data_wire_id, data_2))
+
+      assert_receive {:ib_ex, ^ref, %Proto.ScannerData{scanner_data_element: [e1]}}, 1_000
+      assert e1.contract.symbol == "AAPL"
+
+      assert_receive {:ib_ex, ^ref, %Proto.ScannerData{scanner_data_element: [e2]}}, 1_000
+      assert e2.contract.symbol == "TSLA"
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+
+      scanner_sub = %Proto.ScannerSubscription{
+        instrument: "INVALID",
+        location_code: "INVALID",
+        scan_code: "INVALID"
+      }
+
+      {:ok, ref} = Scanner.subscribe(client, scanner_sub)
+
+      error_proto = %Proto.ErrorMessage{id: 1, error_code: 200, error_msg: "No scanner subscription found"}
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No scanner subscription found"
+    end
+  end
+
+  describe "unsubscribe/2" do
+    test "cancels an active scanner subscription" do
+      client = start_client()
+
+      scanner_sub = %Proto.ScannerSubscription{
+        instrument: "STK",
+        location_code: "STK.US.MAJOR",
+        scan_code: "TOP_PERC_GAIN",
+        number_of_rows: 10
+      }
+
+      {:ok, ref} = Scanner.subscribe(client, scanner_sub)
+      assert :ok = Scanner.unsubscribe(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = Scanner.unsubscribe(client, fake_ref)
+    end
+  end
+
+  describe "parameters/2" do
+    test "sends ScannerParametersRequest and returns {:ok, %ScannerParameters{}}" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Scanner.parameters(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      xml_content =
+        "<ScanParameterResponse><InstrumentList><Instrument>STK</Instrument></InstrumentList></ScanParameterResponse>"
+
+      response = %Proto.ScannerParameters{xml: xml_content}
+      Client.process_message(client, wire_message(@scanner_parameters_wire_id, response))
+
+      assert {:ok, %Proto.ScannerParameters{} = result} = Task.await(task, 5_000)
+      assert result.xml == xml_content
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Scanner.parameters(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `IbEx.Client.Scanner` thematic module with three functions: `subscribe/3` (stream of ScannerData via `Client.subscribe`), `unsubscribe/2` (cancel stream via `Client.unsubscribe`), and `parameters/2` (request/response for ScannerParameters XML via `Client.request` with global correlation)
- Change `ScannerSubscriptionRequest` conversation type from `:bounded_stream` to `:stream` in the conversations registry so it works with `Client.subscribe/3`
- Add 7 tests covering subscribe, unsubscribe, parameters, error handling, and timeout scenarios

## Test plan

- [x] `mix test test/ib_ex/client/scanner_test.exs` -- all 7 new tests pass
- [x] `mix test` -- full suite (479 tests) passes with no failures
- [x] `mix compile --warnings-as-errors` -- clean compilation
- [x] `mix format --check-formatted` -- formatting verified