### PR TITLE
Add Client.Account thematic module

### DIFF
--- a/lib/ib_ex/client/account.ex
+++ b/lib/ib_ex/client/account.ex
@@ -1,0 +1,276 @@
+defmodule IbEx.Client.Account do
+  @moduledoc """
+  Thematic module for account operations.
+
+  Provides high-level functions for querying account data, positions, summaries,
+  and P&L information. This module is stateless -- it builds proto request structs
+  and delegates to `Client.request/3` or `Client.subscribe/3`.
+
+  ## Functions
+
+  * `request_updates/3` - Requests account data updates
+    (bounded stream: accumulates AccountValue, PortfolioValue, AccountUpdateTime responses,
+    ends with AccountDataEnd, global correlation).
+  * `positions/2` - Requests current positions
+    (bounded stream: accumulates Position responses, ends with PositionEnd, global correlation).
+  * `summary/2` - Requests account summary
+    (bounded stream: accumulates AccountSummary responses, ends with AccountSummaryEnd, req_id correlation).
+  * `positions_multi/3` - Requests positions for multiple accounts/models
+    (bounded stream: accumulates PositionMulti responses, ends with PositionMultiEnd, req_id correlation).
+  * `updates_multi/3` - Requests account updates for multiple accounts/models
+    (bounded stream: accumulates AccountUpdateMulti responses, ends with AccountUpdateMultiEnd, req_id correlation).
+  * `pnl/3` - Subscribes to P&L updates for an account
+    (stream subscription with req_id correlation, receives PnL protos).
+  * `pnl_single/4` - Subscribes to single-position P&L updates
+    (stream subscription with req_id correlation, receives PnLSingle protos).
+  * `unsubscribe_pnl/2` - Cancels a P&L subscription.
+  * `unsubscribe_pnl_single/2` - Cancels a single-position P&L subscription.
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  @doc """
+  Requests account data updates for the given account.
+
+  Sends an `AccountDataRequest` through `Client.request/3` using global correlation.
+  The response is a bounded stream that accumulates `AccountValue`, `PortfolioValue`,
+  and `AccountUpdateTime` protos and ends with an `AccountDataEnd` marker.
+
+  Returns `{:ok, [%Proto.AccountValue{} | %Proto.PortfolioValue{} | %Proto.AccountUpdateTime{}, ...]}` on success,
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:subscribe` - Whether to subscribe to updates (default: `true`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, updates} = Account.request_updates(client, "DU123456")
+
+  """
+  @spec request_updates(pid(), String.t(), keyword()) :: {:ok, list()} | {:error, any()}
+  def request_updates(client, acct_code, opts \\ []) do
+    request = %Proto.AccountDataRequest{
+      subscribe: Keyword.get(opts, :subscribe, true),
+      acct_code: acct_code
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests current positions.
+
+  Sends a `PositionsRequest` through `Client.request/3` using global correlation.
+  The response is a bounded stream that accumulates `Position` protos and ends
+  with a `PositionEnd` marker.
+
+  Returns `{:ok, [%Proto.Position{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, positions} = Account.positions(client)
+
+  """
+  @spec positions(pid(), keyword()) :: {:ok, list()} | {:error, any()}
+  def positions(client, opts \\ []) do
+    request = %Proto.PositionsRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests account summary.
+
+  Sends an `AccountSummaryRequest` through `Client.request/3` using req_id correlation.
+  The response is a bounded stream that accumulates `AccountSummary` protos and ends
+  with an `AccountSummaryEnd` marker.
+
+  Returns `{:ok, [%Proto.AccountSummary{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:group` - Account group, e.g. `"All"` (default: `"All"`)
+  * `:tags` - Comma-separated tags, e.g. `"NetLiquidation,TotalCashValue"` (default: `"$LEDGER"`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, summaries} = Account.summary(client)
+      {:ok, summaries} = Account.summary(client, group: "All", tags: "NetLiquidation,TotalCashValue")
+
+  """
+  @spec summary(pid(), keyword()) :: {:ok, list()} | {:error, any()}
+  def summary(client, opts \\ []) do
+    request = %Proto.AccountSummaryRequest{
+      group: Keyword.get(opts, :group, "All"),
+      tags: Keyword.get(opts, :tags, "$LEDGER")
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests positions for multiple accounts/models.
+
+  Sends a `PositionsMultiRequest` through `Client.request/3` using req_id correlation.
+  The response is a bounded stream that accumulates `PositionMulti` protos and ends
+  with a `PositionMultiEnd` marker.
+
+  Returns `{:ok, [%Proto.PositionMulti{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:model_code` - Model code filter (default: `""`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, positions} = Account.positions_multi(client, "DU123456")
+      {:ok, positions} = Account.positions_multi(client, "DU123456", model_code: "myModel")
+
+  """
+  @spec positions_multi(pid(), String.t(), keyword()) :: {:ok, list()} | {:error, any()}
+  def positions_multi(client, account, opts \\ []) do
+    request = %Proto.PositionsMultiRequest{
+      account: account,
+      model_code: Keyword.get(opts, :model_code, "")
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests account updates for multiple accounts/models.
+
+  Sends an `AccountUpdatesMultiRequest` through `Client.request/3` using req_id correlation.
+  The response is a bounded stream that accumulates `AccountUpdateMulti` protos and ends
+  with an `AccountUpdateMultiEnd` marker.
+
+  Returns `{:ok, [%Proto.AccountUpdateMulti{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:model_code` - Model code filter (default: `""`)
+  * `:ledger_and_nlv` - Whether to include ledger and NLV data (default: `true`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, updates} = Account.updates_multi(client, "DU123456")
+      {:ok, updates} = Account.updates_multi(client, "DU123456", model_code: "myModel")
+
+  """
+  @spec updates_multi(pid(), String.t(), keyword()) :: {:ok, list()} | {:error, any()}
+  def updates_multi(client, account, opts \\ []) do
+    request = %Proto.AccountUpdatesMultiRequest{
+      account: account,
+      model_code: Keyword.get(opts, :model_code, ""),
+      ledger_and_nlv: Keyword.get(opts, :ledger_and_nlv, true)
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Subscribes to P&L updates for the given account.
+
+  Builds a `PnLRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with PnL protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:model_code` - Model code filter (default: `""`)
+
+  ## Examples
+
+      {:ok, ref} = Account.pnl(client, "DU123456")
+      {:ok, ref} = Account.pnl(client, "DU123456", model_code: "myModel")
+
+  """
+  @spec pnl(pid(), String.t(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def pnl(client, account, opts \\ []) do
+    request = %Proto.PnLRequest{
+      account: account,
+      model_code: Keyword.get(opts, :model_code, "")
+    }
+
+    Client.subscribe(client, request, opts)
+  end
+
+  @doc """
+  Subscribes to single-position P&L updates.
+
+  Builds a `PnLSingleRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with PnLSingle protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:model_code` - Model code filter (default: `""`)
+
+  ## Examples
+
+      {:ok, ref} = Account.pnl_single(client, "DU123456", 265598)
+      {:ok, ref} = Account.pnl_single(client, "DU123456", 265598, model_code: "myModel")
+
+  """
+  @spec pnl_single(pid(), String.t(), integer(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def pnl_single(client, account, con_id, opts \\ []) when is_integer(con_id) do
+    request = %Proto.PnLSingleRequest{
+      account: account,
+      model_code: Keyword.get(opts, :model_code, ""),
+      con_id: con_id
+    }
+
+    Client.subscribe(client, request, opts)
+  end
+
+  @doc """
+  Cancels a P&L subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelPnL` message
+  and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = Account.unsubscribe_pnl(client, subscription_ref)
+
+  """
+  @spec unsubscribe_pnl(pid(), reference()) :: :ok | {:error, :not_found}
+  def unsubscribe_pnl(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  @doc """
+  Cancels a single-position P&L subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelPnLSingle` message
+  and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = Account.unsubscribe_pnl_single(client, subscription_ref)
+
+  """
+  @spec unsubscribe_pnl_single(pid(), reference()) :: :ok | {:error, :not_found}
+  def unsubscribe_pnl_single(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+end

--- a/test/ib_ex/client/account_test.exs
+++ b/test/ib_ex/client/account_test.exs
@@ -1,0 +1,692 @@
+defmodule IbEx.Client.AccountTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.Account
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @account_value_wire_id 206
+  @portfolio_value_wire_id 207
+  @account_update_time_wire_id 208
+  @account_data_end_wire_id 254
+  @position_wire_id 261
+  @position_end_wire_id 262
+  @account_summary_wire_id 263
+  @account_summary_end_wire_id 264
+  @position_multi_wire_id 271
+  @position_multi_end_wire_id 272
+  @account_update_multi_wire_id 273
+  @account_update_multi_end_wire_id 274
+  @pnl_wire_id 294
+  @pnl_single_wire_id 295
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "request_updates/3" do
+    test "accumulates AccountValue and PortfolioValue responses and returns {:ok, list} on AccountDataEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.request_updates(client, "DU123456", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      account_value = %Proto.AccountValue{
+        key: "NetLiquidation",
+        value: "100000.00",
+        currency: "USD",
+        account_name: "DU123456"
+      }
+
+      portfolio_value = %Proto.PortfolioValue{
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        position: "100",
+        market_price: 150.25,
+        market_value: 15025.0,
+        average_cost: 145.00,
+        unrealized_pnl: 525.0,
+        realized_pnl: 0.0,
+        account_name: "DU123456"
+      }
+
+      account_update_time = %Proto.AccountUpdateTime{time_stamp: "15:30"}
+
+      Client.process_message(client, wire_message(@account_value_wire_id, account_value))
+      Client.process_message(client, wire_message(@portfolio_value_wire_id, portfolio_value))
+      Client.process_message(client, wire_message(@account_update_time_wire_id, account_update_time))
+
+      end_marker = %Proto.AccountDataEnd{account_name: "DU123456"}
+      Client.process_message(client, wire_message(@account_data_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 3
+
+      [first, second, third] = results
+      assert %Proto.AccountValue{} = first
+      assert first.key == "NetLiquidation"
+      assert first.value == "100000.00"
+      assert first.currency == "USD"
+      assert first.account_name == "DU123456"
+
+      assert %Proto.PortfolioValue{} = second
+      assert second.contract.symbol == "AAPL"
+      assert second.position == "100"
+      assert second.market_price == 150.25
+      assert second.market_value == 15025.0
+      assert second.unrealized_pnl == 525.0
+
+      assert %Proto.AccountUpdateTime{} = third
+      assert third.time_stamp == "15:30"
+    end
+
+    test "returns {:ok, []} when no account data exists" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.request_updates(client, "DU123456", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.AccountDataEnd{account_name: "DU123456"}
+      Client.process_message(client, wire_message(@account_data_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Account.request_updates(client, "DU123456", timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "positions/2" do
+    test "accumulates Position responses and returns {:ok, list} on PositionEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.positions(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      position_1 = %Proto.Position{
+        account: "DU123456",
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        position: "100",
+        avg_cost: 145.00
+      }
+
+      position_2 = %Proto.Position{
+        account: "DU123456",
+        contract: %Proto.Contract{symbol: "MSFT", sec_type: "STK", currency: "USD"},
+        position: "50",
+        avg_cost: 380.00
+      }
+
+      Client.process_message(client, wire_message(@position_wire_id, position_1))
+      Client.process_message(client, wire_message(@position_wire_id, position_2))
+
+      end_marker = %Proto.PositionEnd{}
+      Client.process_message(client, wire_message(@position_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.Position{} = first
+      assert first.account == "DU123456"
+      assert first.contract.symbol == "AAPL"
+      assert first.position == "100"
+      assert first.avg_cost == 145.00
+
+      assert %Proto.Position{} = second
+      assert second.contract.symbol == "MSFT"
+      assert second.position == "50"
+      assert second.avg_cost == 380.00
+    end
+
+    test "returns {:ok, []} when no positions exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.positions(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.PositionEnd{}
+      Client.process_message(client, wire_message(@position_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Account.positions(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "summary/2" do
+    test "accumulates AccountSummary responses and returns {:ok, list} on AccountSummaryEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.summary(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      summary_1 = %Proto.AccountSummary{
+        req_id: 1,
+        account: "DU123456",
+        tag: "NetLiquidation",
+        value: "100000.00",
+        currency: "USD"
+      }
+
+      summary_2 = %Proto.AccountSummary{
+        req_id: 1,
+        account: "DU123456",
+        tag: "TotalCashValue",
+        value: "50000.00",
+        currency: "USD"
+      }
+
+      Client.process_message(client, wire_message(@account_summary_wire_id, summary_1))
+      Client.process_message(client, wire_message(@account_summary_wire_id, summary_2))
+
+      end_marker = %Proto.AccountSummaryEnd{req_id: 1}
+      Client.process_message(client, wire_message(@account_summary_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.AccountSummary{} = first
+      assert first.req_id == 1
+      assert first.account == "DU123456"
+      assert first.tag == "NetLiquidation"
+      assert first.value == "100000.00"
+      assert first.currency == "USD"
+
+      assert %Proto.AccountSummary{} = second
+      assert second.tag == "TotalCashValue"
+      assert second.value == "50000.00"
+    end
+
+    test "returns {:ok, []} when no summary data exists" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.summary(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.AccountSummaryEnd{req_id: 1}
+      Client.process_message(client, wire_message(@account_summary_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.summary(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 321,
+        error_msg: "Error validating request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 321
+      assert error.message == "Error validating request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Account.summary(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "positions_multi/3" do
+    test "accumulates PositionMulti responses and returns {:ok, list} on PositionMultiEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.positions_multi(client, "DU123456", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      position_1 = %Proto.PositionMulti{
+        req_id: 1,
+        account: "DU123456",
+        contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
+        position: "100",
+        avg_cost: 145.00,
+        model_code: ""
+      }
+
+      position_2 = %Proto.PositionMulti{
+        req_id: 1,
+        account: "DU123456",
+        contract: %Proto.Contract{symbol: "MSFT", sec_type: "STK", currency: "USD"},
+        position: "50",
+        avg_cost: 380.00,
+        model_code: ""
+      }
+
+      Client.process_message(client, wire_message(@position_multi_wire_id, position_1))
+      Client.process_message(client, wire_message(@position_multi_wire_id, position_2))
+
+      end_marker = %Proto.PositionMultiEnd{req_id: 1}
+      Client.process_message(client, wire_message(@position_multi_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.PositionMulti{} = first
+      assert first.req_id == 1
+      assert first.account == "DU123456"
+      assert first.contract.symbol == "AAPL"
+      assert first.position == "100"
+      assert first.avg_cost == 145.00
+
+      assert %Proto.PositionMulti{} = second
+      assert second.contract.symbol == "MSFT"
+      assert second.position == "50"
+      assert second.avg_cost == 380.00
+    end
+
+    test "returns {:ok, []} when no positions exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.positions_multi(client, "DU123456", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.PositionMultiEnd{req_id: 1}
+      Client.process_message(client, wire_message(@position_multi_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.positions_multi(client, "INVALID", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 321,
+        error_msg: "Error validating request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 321
+      assert error.message == "Error validating request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Account.positions_multi(client, "DU123456", timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "updates_multi/3" do
+    test "accumulates AccountUpdateMulti responses and returns {:ok, list} on AccountUpdateMultiEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.updates_multi(client, "DU123456", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      update_1 = %Proto.AccountUpdateMulti{
+        req_id: 1,
+        account: "DU123456",
+        model_code: "",
+        key: "NetLiquidation",
+        value: "100000.00",
+        currency: "USD"
+      }
+
+      update_2 = %Proto.AccountUpdateMulti{
+        req_id: 1,
+        account: "DU123456",
+        model_code: "",
+        key: "TotalCashValue",
+        value: "50000.00",
+        currency: "USD"
+      }
+
+      Client.process_message(client, wire_message(@account_update_multi_wire_id, update_1))
+      Client.process_message(client, wire_message(@account_update_multi_wire_id, update_2))
+
+      end_marker = %Proto.AccountUpdateMultiEnd{req_id: 1}
+      Client.process_message(client, wire_message(@account_update_multi_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.AccountUpdateMulti{} = first
+      assert first.req_id == 1
+      assert first.account == "DU123456"
+      assert first.key == "NetLiquidation"
+      assert first.value == "100000.00"
+      assert first.currency == "USD"
+
+      assert %Proto.AccountUpdateMulti{} = second
+      assert second.key == "TotalCashValue"
+      assert second.value == "50000.00"
+    end
+
+    test "returns {:ok, []} when no updates exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.updates_multi(client, "DU123456", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.AccountUpdateMultiEnd{req_id: 1}
+      Client.process_message(client, wire_message(@account_update_multi_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Account.updates_multi(client, "INVALID", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 321,
+        error_msg: "Error validating request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 321
+      assert error.message == "Error validating request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Account.updates_multi(client, "DU123456", timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "pnl/3" do
+    test "subscribes to PnL updates and receives PnL messages" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl(client, "DU123456")
+      assert is_reference(ref)
+
+      pnl_response = %Proto.PnL{
+        req_id: 1,
+        daily_pn_l: 1250.50,
+        unrealized_pn_l: 3200.00,
+        realized_pn_l: 500.00
+      }
+
+      Client.process_message(client, wire_message(@pnl_wire_id, pnl_response))
+
+      assert_receive {:ib_ex, ^ref, %Proto.PnL{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.daily_pn_l == 1250.50
+      assert received.unrealized_pn_l == 3200.00
+      assert received.realized_pn_l == 500.00
+    end
+
+    test "receives multiple PnL updates on the same subscription" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl(client, "DU123456")
+
+      pnl_1 = %Proto.PnL{req_id: 1, daily_pn_l: 1250.50, unrealized_pn_l: 3200.00, realized_pn_l: 500.00}
+      pnl_2 = %Proto.PnL{req_id: 1, daily_pn_l: 1300.75, unrealized_pn_l: 3250.00, realized_pn_l: 500.00}
+
+      Client.process_message(client, wire_message(@pnl_wire_id, pnl_1))
+      Client.process_message(client, wire_message(@pnl_wire_id, pnl_2))
+
+      assert_receive {:ib_ex, ^ref, %Proto.PnL{daily_pn_l: 1250.50}}, 1_000
+      assert_receive {:ib_ex, ^ref, %Proto.PnL{daily_pn_l: 1300.75}}, 1_000
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl(client, "INVALID")
+
+      error_proto = %Proto.ErrorMessage{id: 1, error_code: 321, error_msg: "Error validating request"}
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.id == 1
+      assert error.code == 321
+      assert error.message == "Error validating request"
+    end
+  end
+
+  describe "pnl_single/4" do
+    test "subscribes to single-position PnL updates and receives PnLSingle messages" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl_single(client, "DU123456", 265_598)
+      assert is_reference(ref)
+
+      pnl_single_response = %Proto.PnLSingle{
+        req_id: 1,
+        position: "100",
+        daily_pn_l: 325.50,
+        unrealized_pn_l: 1200.00,
+        realized_pn_l: 0.0,
+        value: 15025.0
+      }
+
+      Client.process_message(client, wire_message(@pnl_single_wire_id, pnl_single_response))
+
+      assert_receive {:ib_ex, ^ref, %Proto.PnLSingle{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.position == "100"
+      assert received.daily_pn_l == 325.50
+      assert received.unrealized_pn_l == 1200.00
+      assert received.realized_pn_l == 0.0
+      assert received.value == 15025.0
+    end
+
+    test "receives multiple PnLSingle updates on the same subscription" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl_single(client, "DU123456", 265_598)
+
+      pnl_1 = %Proto.PnLSingle{
+        req_id: 1,
+        position: "100",
+        daily_pn_l: 325.50,
+        unrealized_pn_l: 1200.00,
+        realized_pn_l: 0.0,
+        value: 15025.0
+      }
+
+      pnl_2 = %Proto.PnLSingle{
+        req_id: 1,
+        position: "100",
+        daily_pn_l: 350.00,
+        unrealized_pn_l: 1250.00,
+        realized_pn_l: 0.0,
+        value: 15050.0
+      }
+
+      Client.process_message(client, wire_message(@pnl_single_wire_id, pnl_1))
+      Client.process_message(client, wire_message(@pnl_single_wire_id, pnl_2))
+
+      assert_receive {:ib_ex, ^ref, %Proto.PnLSingle{daily_pn_l: 325.50}}, 1_000
+      assert_receive {:ib_ex, ^ref, %Proto.PnLSingle{daily_pn_l: 350.00, value: 15050.0}}, 1_000
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl_single(client, "INVALID", 0)
+
+      error_proto = %Proto.ErrorMessage{id: 1, error_code: 321, error_msg: "Error validating request"}
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.id == 1
+      assert error.code == 321
+      assert error.message == "Error validating request"
+    end
+  end
+
+  describe "unsubscribe_pnl/2" do
+    test "cancels an active PnL subscription" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl(client, "DU123456")
+      assert :ok = Account.unsubscribe_pnl(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = Account.unsubscribe_pnl(client, fake_ref)
+    end
+  end
+
+  describe "unsubscribe_pnl_single/2" do
+    test "cancels an active PnLSingle subscription" do
+      client = start_client()
+
+      {:ok, ref} = Account.pnl_single(client, "DU123456", 265_598)
+      assert :ok = Account.unsubscribe_pnl_single(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = Account.unsubscribe_pnl_single(client, fake_ref)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `IbEx.Client.Account` thematic module with 9 public functions covering account data, positions, summaries, and P&L operations
- `request_updates/3`, `positions/2`, `summary/2` use `Client.request/3` for bounded streams (global and req_id correlation)
- `positions_multi/3`, `updates_multi/3` use `Client.request/3` for req_id bounded streams
- `pnl/3`, `pnl_single/4` use `Client.subscribe/3` for continuous streams with `unsubscribe_pnl/2` and `unsubscribe_pnl_single/2` cancellation

## Test plan

- [x] 28 tests covering all 9 public functions
- [x] Bounded stream functions tested for: accumulation of responses, empty results, error handling, and timeouts
- [x] Stream subscription functions tested for: receiving messages, multiple updates, and error handling
- [x] Unsubscribe functions tested for: active subscription cancellation and unknown ref error
- [x] Full test suite passes (500 tests, 0 failures)
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes