### PR TITLE
Add Client.News thematic module

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -284,6 +284,9 @@ defmodule IbEx.Client do
 
           {:order_id, order_id} ->
             send_to_tws(state, struct!(cancel_module, order_id: order_id))
+
+          {:global, _request_module} ->
+            send_to_tws(state, struct!(cancel_module))
         end
 
       :error ->
@@ -295,6 +298,7 @@ defmodule IbEx.Client do
 
   defp set_correlation_id(message_type, proto_msg, id) do
     case Conversations.conversation_for(message_type) do
+      {:ok, %{correlation: :global}} -> proto_msg
       {:ok, %{correlation: :order_id}} -> %{proto_msg | order_id: id}
       _ -> %{proto_msg | req_id: id}
     end
@@ -378,7 +382,10 @@ defmodule IbEx.Client do
 
   defp dispatch_by_module(module, msg, table_ref) do
     case find_global_conversation(module, table_ref) do
-      {:ok, key, entry} ->
+      {:ok, _key, %{type: :stream, subscriber: subscriber, subscription_ref: ref}} ->
+        send(subscriber, {:ib_ex, ref, msg})
+
+      {:ok, key, %{type: :request} = entry} ->
         handle_conversation_response(table_ref, key, msg, module, entry)
 
       :not_found ->
@@ -399,7 +406,7 @@ defmodule IbEx.Client do
       key = {:global, request_module}
 
       case Subscriptions.lookup(table_ref, key) do
-        {:ok, %{type: :request} = entry} -> {:ok, key, entry}
+        {:ok, entry} -> {:ok, key, entry}
         _ -> nil
       end
     end)

--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -527,13 +527,7 @@ defmodule IbEx.Client.Conversations do
   def register_stream(table_ref, request_module, subscriber) do
     case conversation_for(request_module) do
       {:ok, %{type: :stream, correlation: correlation}} ->
-        req_id = Subscriptions.allocate_request_id(table_ref)
-
-        key =
-          case correlation do
-            :order_id -> {:order_id, req_id}
-            _ -> {:request_id, req_id}
-          end
+        {key, req_id} = build_stream_key(correlation, table_ref, request_module)
 
         subscription_ref = make_ref()
         monitor_ref = Process.monitor(subscriber)
@@ -546,6 +540,20 @@ defmodule IbEx.Client.Conversations do
     end
   end
 
+  defp build_stream_key(:global, _table_ref, request_module) do
+    {{:global, request_module}, nil}
+  end
+
+  defp build_stream_key(:order_id, table_ref, _request_module) do
+    req_id = Subscriptions.allocate_request_id(table_ref)
+    {{:order_id, req_id}, req_id}
+  end
+
+  defp build_stream_key(_correlation, table_ref, _request_module) do
+    req_id = Subscriptions.allocate_request_id(table_ref)
+    {{:request_id, req_id}, req_id}
+  end
+
   defp build_key(:req_id, table_ref, _request_module) do
     req_id = Subscriptions.allocate_request_id(table_ref)
     {{:request_id, req_id}, req_id}
@@ -556,8 +564,8 @@ defmodule IbEx.Client.Conversations do
   end
 
   defp build_key(:order_id, table_ref, _request_module) do
-    order_id = Subscriptions.allocate_request_id(table_ref)
-    {{:order_id, order_id}, order_id}
+    req_id = Subscriptions.allocate_request_id(table_ref)
+    {{:order_id, req_id}, req_id}
   end
 
   defp end_markers do

--- a/lib/ib_ex/client/news.ex
+++ b/lib/ib_ex/client/news.ex
@@ -1,0 +1,159 @@
+defmodule IbEx.Client.News do
+  @moduledoc """
+  Thematic module for news operations.
+
+  Provides high-level functions for querying news providers, fetching news
+  articles, requesting historical news, and subscribing to news bulletins.
+  This module is stateless -- it builds proto request structs and delegates
+  to `Client.request/3`, `Client.subscribe/3`, and `Client.unsubscribe/2`.
+
+  ## Functions
+
+  * `providers/2` - Requests the list of available news providers
+    (single request/response, global correlation).
+  * `article/3` - Requests a specific news article by provider code and article ID
+    (single request/response, req_id correlation).
+  * `historical/3` - Requests historical news headlines for a contract
+    (bounded stream: accumulates HistoricalNews responses, ends with HistoricalNewsEnd).
+  * `subscribe_bulletins/2` - Subscribes to IB news bulletins
+    (continuous global stream of NewsBulletin messages).
+  * `unsubscribe_bulletins/1` - Cancels a news bulletins subscription.
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  @doc """
+  Requests the list of available news providers.
+
+  Sends a `NewsProvidersRequest` through `Client.request/3` using global correlation.
+
+  Returns `{:ok, %Proto.NewsProviders{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.NewsProviders{news_providers: providers}} = News.providers(client)
+
+  """
+  @spec providers(pid(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def providers(client, opts \\ []) do
+    request = %Proto.NewsProvidersRequest{}
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests a specific news article.
+
+  Sends a `NewsArticleRequest` through `Client.request/3` using req_id correlation.
+
+  Returns `{:ok, %Proto.NewsArticle{}}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:news_article_options` - Map of additional options (default: `%{}`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, %Proto.NewsArticle{article_type: type, article_text: text}} =
+        News.article(client, "BRFG", "BRFG$12345678")
+
+  """
+  @spec article(pid(), String.t(), String.t(), keyword()) :: {:ok, struct()} | {:error, any()}
+  def article(client, provider_code, article_id, opts \\ []) do
+    request = %Proto.NewsArticleRequest{
+      provider_code: provider_code,
+      article_id: article_id,
+      news_article_options: Keyword.get(opts, :news_article_options, %{})
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Requests historical news headlines for the given contract ID.
+
+  Sends a `HistoricalNewsRequest` through `Client.request/3` as a bounded stream.
+  The response accumulates `HistoricalNews` protos and ends with a `HistoricalNewsEnd`
+  marker.
+
+  Returns `{:ok, [%Proto.HistoricalNews{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:provider_codes` - Comma-separated string of provider codes to filter (default: `""`)
+  * `:start_date_time` - Start date/time string (default: `""`)
+  * `:end_date_time` - End date/time string (default: `""`)
+  * `:total_results` - Maximum number of results to return (default: `10`)
+  * `:historical_news_options` - Map of additional options (default: `%{}`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, headlines} = News.historical(client, 265598, provider_codes: "BRFG+BRFUPDN")
+
+  """
+  @spec historical(pid(), integer(), keyword()) :: {:ok, list()} | {:error, any()}
+  def historical(client, con_id, opts \\ []) when is_integer(con_id) do
+    request = %Proto.HistoricalNewsRequest{
+      con_id: con_id,
+      provider_codes: Keyword.get(opts, :provider_codes, ""),
+      start_date_time: Keyword.get(opts, :start_date_time, ""),
+      end_date_time: Keyword.get(opts, :end_date_time, ""),
+      total_results: Keyword.get(opts, :total_results, 10),
+      historical_news_options: Keyword.get(opts, :historical_news_options, %{})
+    }
+
+    Client.request(client, request, opts)
+  end
+
+  @doc """
+  Subscribes to IB news bulletins.
+
+  Sends a `NewsBulletinsRequest` through `Client.subscribe/3` using global correlation.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with `NewsBulletin` protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:all_messages` - If `true`, returns all existing bulletins for the current day
+    in addition to new ones (default: `true`)
+
+  ## Examples
+
+      {:ok, ref} = News.subscribe_bulletins(client)
+
+  """
+  @spec subscribe_bulletins(pid(), keyword()) :: {:ok, reference()} | {:error, any()}
+  def subscribe_bulletins(client, opts \\ []) do
+    request = %Proto.NewsBulletinsRequest{
+      all_messages: Keyword.get(opts, :all_messages, true)
+    }
+
+    Client.subscribe(client, request, opts)
+  end
+
+  @doc """
+  Cancels a news bulletins subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelNewsBulletins` message
+  and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = News.unsubscribe_bulletins(client, subscription_ref)
+
+  """
+  @spec unsubscribe_bulletins(pid(), reference()) :: :ok | {:error, :not_found}
+  def unsubscribe_bulletins(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+end

--- a/test/ib_ex/client/news_test.exs
+++ b/test/ib_ex/client/news_test.exs
@@ -1,0 +1,341 @@
+defmodule IbEx.Client.NewsTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.News
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @news_providers_wire_id 285
+  @news_article_wire_id 283
+  @historical_news_wire_id 286
+  @historical_news_end_wire_id 287
+  @news_bulletin_wire_id 214
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  describe "providers/2" do
+    test "sends NewsProvidersRequest and returns {:ok, %NewsProviders{}} on response" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.providers(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      provider_1 = %Proto.NewsProvider{provider_code: "BRFG", provider_name: "Briefing.com General"}
+      provider_2 = %Proto.NewsProvider{provider_code: "BRFUPDN", provider_name: "Briefing.com Upgrades/Downgrades"}
+
+      response = %Proto.NewsProviders{news_providers: [provider_1, provider_2]}
+      Client.process_message(client, wire_message(@news_providers_wire_id, response))
+
+      assert {:ok, %Proto.NewsProviders{} = result} = Task.await(task, 5_000)
+      assert length(result.news_providers) == 2
+
+      [first, second] = result.news_providers
+      assert first.provider_code == "BRFG"
+      assert first.provider_name == "Briefing.com General"
+      assert second.provider_code == "BRFUPDN"
+      assert second.provider_name == "Briefing.com Upgrades/Downgrades"
+    end
+
+    test "returns {:ok, %NewsProviders{}} with empty list when no providers available" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.providers(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.NewsProviders{news_providers: []}
+      Client.process_message(client, wire_message(@news_providers_wire_id, response))
+
+      assert {:ok, %Proto.NewsProviders{news_providers: []}} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          News.providers(client, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "article/3" do
+    test "sends NewsArticleRequest and returns {:ok, %NewsArticle{}} on response" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.article(client, "BRFG", "BRFG$12345678", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      response = %Proto.NewsArticle{
+        req_id: 1,
+        article_type: 0,
+        article_text: "This is the full article text content."
+      }
+
+      Client.process_message(client, wire_message(@news_article_wire_id, response))
+
+      assert {:ok, %Proto.NewsArticle{} = result} = Task.await(task, 5_000)
+      assert result.req_id == 1
+      assert result.article_type == 0
+      assert result.article_text == "This is the full article text content."
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.article(client, "INVALID", "INVALID$999", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          News.article(client, "BRFG", "BRFG$12345678", timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "historical/3" do
+    test "accumulates HistoricalNews responses and returns {:ok, list} on HistoricalNewsEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.historical(client, 265_598, provider_codes: "BRFG", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      headline_1 = %Proto.HistoricalNews{
+        req_id: 1,
+        time: "2024-01-15 10:30:00",
+        provider_code: "BRFG",
+        article_id: "BRFG$12345678",
+        headline: "AAPL: Apple reports record earnings"
+      }
+
+      headline_2 = %Proto.HistoricalNews{
+        req_id: 1,
+        time: "2024-01-14 09:00:00",
+        provider_code: "BRFG",
+        article_id: "BRFG$12345679",
+        headline: "AAPL: New product announcement expected"
+      }
+
+      Client.process_message(client, wire_message(@historical_news_wire_id, headline_1))
+      Client.process_message(client, wire_message(@historical_news_wire_id, headline_2))
+
+      end_marker = %Proto.HistoricalNewsEnd{req_id: 1, has_more: false}
+      Client.process_message(client, wire_message(@historical_news_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.HistoricalNews{} = first
+      assert first.time == "2024-01-15 10:30:00"
+      assert first.provider_code == "BRFG"
+      assert first.article_id == "BRFG$12345678"
+      assert first.headline == "AAPL: Apple reports record earnings"
+
+      assert %Proto.HistoricalNews{} = second
+      assert second.time == "2024-01-14 09:00:00"
+      assert second.article_id == "BRFG$12345679"
+      assert second.headline == "AAPL: New product announcement expected"
+    end
+
+    test "returns {:ok, []} when no historical news exists" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.historical(client, 265_598, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.HistoricalNewsEnd{req_id: 1, has_more: false}
+      Client.process_message(client, wire_message(@historical_news_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          News.historical(client, 999_999, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          News.historical(client, 265_598, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+  end
+
+  describe "subscribe_bulletins/2" do
+    test "subscribes to news bulletins and receives NewsBulletin messages" do
+      client = start_client()
+
+      {:ok, ref} = News.subscribe_bulletins(client)
+      assert is_reference(ref)
+
+      bulletin = %Proto.NewsBulletin{
+        news_msg_id: 1,
+        news_msg_type: 1,
+        news_message: "Exchange NYSE is experiencing connectivity issues.",
+        originating_exch: "NYSE"
+      }
+
+      Client.process_message(client, wire_message(@news_bulletin_wire_id, bulletin))
+
+      assert_receive {:ib_ex, ^ref, %Proto.NewsBulletin{} = received}, 1_000
+      assert received.news_msg_id == 1
+      assert received.news_msg_type == 1
+      assert received.news_message == "Exchange NYSE is experiencing connectivity issues."
+      assert received.originating_exch == "NYSE"
+    end
+
+    test "receives multiple NewsBulletin messages on the same subscription" do
+      client = start_client()
+
+      {:ok, ref} = News.subscribe_bulletins(client)
+
+      bulletin_1 = %Proto.NewsBulletin{
+        news_msg_id: 1,
+        news_msg_type: 1,
+        news_message: "First bulletin message.",
+        originating_exch: "NYSE"
+      }
+
+      bulletin_2 = %Proto.NewsBulletin{
+        news_msg_id: 2,
+        news_msg_type: 2,
+        news_message: "Second bulletin message.",
+        originating_exch: "NASDAQ"
+      }
+
+      Client.process_message(client, wire_message(@news_bulletin_wire_id, bulletin_1))
+      Client.process_message(client, wire_message(@news_bulletin_wire_id, bulletin_2))
+
+      assert_receive {:ib_ex, ^ref, %Proto.NewsBulletin{news_msg_id: 1, originating_exch: "NYSE"}}, 1_000
+      assert_receive {:ib_ex, ^ref, %Proto.NewsBulletin{news_msg_id: 2, originating_exch: "NASDAQ"}}, 1_000
+    end
+
+    test "accepts all_messages option" do
+      client = start_client()
+
+      {:ok, ref} = News.subscribe_bulletins(client, all_messages: false)
+      assert is_reference(ref)
+    end
+  end
+
+  describe "unsubscribe_bulletins/2" do
+    test "cancels an active news bulletins subscription" do
+      client = start_client()
+
+      {:ok, ref} = News.subscribe_bulletins(client)
+      assert :ok = News.unsubscribe_bulletins(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = News.unsubscribe_bulletins(client, fake_ref)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `IbEx.Client.News` thematic module with `providers/2` (request_response, global), `article/4` (request_response, req_id), `historical/3` (bounded_stream, req_id), `subscribe_bulletins/2` (stream, global), and `unsubscribe_bulletins/2`
- Add global stream subscription support in `Client` and `Conversations` — `register_stream/3` now handles `:global` correlation, `set_correlation_id/3` skips ID assignment for global streams, `cancel_stream/4` sends cancel without an ID field, and `find_global_conversation/2` matches both `:request` and `:stream` entry types
- Add 15 tests covering all News functions with strong assertions on response field values, error handling, and timeout behavior

## Test plan
- [x] All 15 new tests in `news_test.exs` pass (providers, article, historical, subscribe/unsubscribe bulletins)
- [x] Full test suite passes (487 tests, 0 failures)
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes