### PR TITLE
Parse valid_exchanges and order_types into lists of strings

### DIFF
--- a/lib/ib_ex/client/types/contract_details.ex
+++ b/lib/ib_ex/client/types/contract_details.ex
@@ -15,8 +15,8 @@ defmodule IbEx.Client.Types.ContractDetails do
   defstruct contract: nil,
             market_name: nil,
             min_tick: 0.0,
-            order_types: nil,
-            valid_exchanges: nil,
+            order_types: [],
+            valid_exchanges: [],
             price_magnifier: 0,
             under_conid: 0,
             long_name: nil,
@@ -50,8 +50,8 @@ defmodule IbEx.Client.Types.ContractDetails do
           contract: Contract.t() | nil,
           market_name: binary() | nil,
           min_tick: float(),
-          order_types: binary() | nil,
-          valid_exchanges: binary() | nil,
+          order_types: list(String.t()),
+          valid_exchanges: list(String.t()),
           price_magnifier: non_neg_integer(),
           under_conid: non_neg_integer(),
           long_name: binary() | nil,
@@ -91,6 +91,8 @@ defmodule IbEx.Client.Types.ContractDetails do
   def new(attrs) when is_map(attrs) do
     attrs =
       attrs
+      |> parse_comma_separated(:order_types)
+      |> parse_comma_separated(:valid_exchanges)
       |> assign_params(:bond_details, BondDetails)
       |> assign_params(:fund_details, FundDetails)
       |> assign_params(:event_contract, EventContract)
@@ -106,6 +108,15 @@ defmodule IbEx.Client.Types.ContractDetails do
       value when is_map(value) -> Map.put(attrs, key, module.new(value))
       %{__struct__: _} = value -> Map.put(attrs, key, value)
       _ -> attrs
+    end
+  end
+
+  defp parse_comma_separated(attrs, key) do
+    case Map.get(attrs, key) do
+      nil -> Map.put(attrs, key, [])
+      value when is_binary(value) -> Map.put(attrs, key, String.split(value, ",", trim: true))
+      value when is_list(value) -> Map.put(attrs, key, value)
+      _ -> Map.put(attrs, key, [])
     end
   end
 end

--- a/test/ib_ex/client/types/contract_details_test.exs
+++ b/test/ib_ex/client/types/contract_details_test.exs
@@ -1,0 +1,87 @@
+defmodule IbEx.Client.Types.ContractDetailsTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.ContractDetails
+
+  describe "new/1 valid_exchanges parsing" do
+    test "parses comma-separated valid_exchanges string into a list of strings" do
+      details = ContractDetails.new(%{valid_exchanges: "SMART,AMEX,NYSE"})
+
+      assert details.valid_exchanges == ["SMART", "AMEX", "NYSE"]
+    end
+
+    test "returns empty list when valid_exchanges is nil" do
+      details = ContractDetails.new(%{valid_exchanges: nil})
+
+      assert details.valid_exchanges == []
+    end
+
+    test "returns empty list when valid_exchanges is an empty string" do
+      details = ContractDetails.new(%{valid_exchanges: ""})
+
+      assert details.valid_exchanges == []
+    end
+
+    test "preserves an already-parsed list for valid_exchanges" do
+      details = ContractDetails.new(%{valid_exchanges: ["SMART", "AMEX"]})
+
+      assert details.valid_exchanges == ["SMART", "AMEX"]
+    end
+
+    test "returns empty list when valid_exchanges is not provided" do
+      details = ContractDetails.new(%{})
+
+      assert details.valid_exchanges == []
+    end
+  end
+
+  describe "new/1 order_types parsing" do
+    test "parses comma-separated order_types string into a list of strings" do
+      details = ContractDetails.new(%{order_types: "ACTIVETIM,AUC,COND"})
+
+      assert details.order_types == ["ACTIVETIM", "AUC", "COND"]
+    end
+
+    test "returns empty list when order_types is nil" do
+      details = ContractDetails.new(%{order_types: nil})
+
+      assert details.order_types == []
+    end
+
+    test "returns empty list when order_types is an empty string" do
+      details = ContractDetails.new(%{order_types: ""})
+
+      assert details.order_types == []
+    end
+
+    test "preserves an already-parsed list for order_types" do
+      details = ContractDetails.new(%{order_types: ["ACTIVETIM", "AUC"]})
+
+      assert details.order_types == ["ACTIVETIM", "AUC"]
+    end
+
+    test "returns empty list when order_types is not provided" do
+      details = ContractDetails.new(%{})
+
+      assert details.order_types == []
+    end
+  end
+
+  describe "new/1 with keyword list" do
+    test "parses valid_exchanges and order_types from keyword list attrs" do
+      details = ContractDetails.new(valid_exchanges: "SMART,AMEX", order_types: "MKT,LMT")
+
+      assert details.valid_exchanges == ["SMART", "AMEX"]
+      assert details.order_types == ["MKT", "LMT"]
+    end
+  end
+
+  describe "new/0" do
+    test "creates a ContractDetails with default empty lists for valid_exchanges and order_types" do
+      details = ContractDetails.new()
+
+      assert details.valid_exchanges == []
+      assert details.order_types == []
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Parse `valid_exchanges` and `order_types` from comma-separated strings into `list(String.t())` in `ContractDetails`
- Default values changed from `nil` to `[]`
- Added `parse_comma_separated/2` helper that handles nil, empty string, and already-parsed lists

## Test plan
- [x] 12 new tests covering both fields (comma-separated, nil, empty, list passthrough, defaults)
- [x] All 541 tests pass
- [x] Clean compile with `--warnings-as-errors`

vtb: 041984e0-bf64-4645-ab45-c2714d1383b7