### PR TITLE
Add Client.Options thematic module

### DIFF
--- a/lib/ib_ex/client/options.ex
+++ b/lib/ib_ex/client/options.ex
@@ -1,0 +1,158 @@
+defmodule IbEx.Client.Options do
+  @moduledoc """
+  Thematic module for options operations.
+
+  Provides high-level functions for calculating implied volatility, option
+  prices, and querying security definition option parameters. This module
+  is stateless -- it builds proto request structs and delegates to
+  `Client.subscribe/3`, `Client.unsubscribe/2`, and `Client.request/3`.
+
+  ## Functions
+
+  * `implied_volatility/3` - Subscribes to implied volatility calculations
+    (stream subscription with req_id correlation, receives TickOptionComputation protos).
+  * `cancel_implied_volatility/2` - Cancels an implied volatility subscription.
+  * `option_price/3` - Subscribes to option price calculations
+    (stream subscription with req_id correlation, receives TickOptionComputation protos).
+  * `cancel_option_price/2` - Cancels an option price subscription.
+  * `sec_def_params/3` - Requests security definition option parameters
+    (bounded stream: accumulates SecDefOptParameter responses, ends with SecDefOptParameterEnd).
+  """
+
+  alias IbEx.Client
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  @doc """
+  Subscribes to implied volatility calculations for the given contract.
+
+  Builds a `CalculateImpliedVolatilityRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with
+  `TickOptionComputation` protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:implied_volatility_options` - Map of additional options (default: `%{}`)
+
+  ## Examples
+
+      contract = %Proto.Contract{symbol: "AAPL", sec_type: "OPT", currency: "USD"}
+      {:ok, ref} = Options.implied_volatility(client, contract, 150.0, 155.0)
+
+  """
+  @spec implied_volatility(pid(), struct(), number(), number(), keyword()) ::
+          {:ok, reference()} | {:error, any()}
+  def implied_volatility(client, contract, option_price, under_price, opts \\ []) do
+    request = %Proto.CalculateImpliedVolatilityRequest{
+      contract: contract,
+      option_price: option_price,
+      under_price: under_price,
+      implied_volatility_options: Keyword.get(opts, :implied_volatility_options, %{})
+    }
+
+    Client.subscribe(client, request, opts)
+  end
+
+  @doc """
+  Cancels an implied volatility calculation subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelCalculateImpliedVolatility`
+  message and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = Options.cancel_implied_volatility(client, subscription_ref)
+
+  """
+  @spec cancel_implied_volatility(pid(), reference()) :: :ok | {:error, :not_found}
+  def cancel_implied_volatility(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  @doc """
+  Subscribes to option price calculations for the given contract.
+
+  Builds a `CalculateOptionPriceRequest` and sends it through `Client.subscribe/3`.
+  The caller receives `{:ib_ex, subscription_ref, msg}` messages with
+  `TickOptionComputation` protos.
+
+  Returns `{:ok, subscription_ref}` on success, or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:option_price_options` - Map of additional options (default: `%{}`)
+
+  ## Examples
+
+      contract = %Proto.Contract{symbol: "AAPL", sec_type: "OPT", currency: "USD"}
+      {:ok, ref} = Options.option_price(client, contract, 0.25, 155.0)
+
+  """
+  @spec option_price(pid(), struct(), number(), number(), keyword()) ::
+          {:ok, reference()} | {:error, any()}
+  def option_price(client, contract, volatility, under_price, opts \\ []) do
+    request = %Proto.CalculateOptionPriceRequest{
+      contract: contract,
+      volatility: volatility,
+      under_price: under_price,
+      option_price_options: Keyword.get(opts, :option_price_options, %{})
+    }
+
+    Client.subscribe(client, request, opts)
+  end
+
+  @doc """
+  Cancels an option price calculation subscription.
+
+  Delegates to `Client.unsubscribe/2` which sends a `CancelCalculateOptionPrice`
+  message and removes the subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription does not exist.
+
+  ## Examples
+
+      :ok = Options.cancel_option_price(client, subscription_ref)
+
+  """
+  @spec cancel_option_price(pid(), reference()) :: :ok | {:error, :not_found}
+  def cancel_option_price(client, subscription_ref) do
+    Client.unsubscribe(client, subscription_ref)
+  end
+
+  @doc """
+  Requests security definition option parameters for the given underlying.
+
+  Sends a `SecDefOptParamsRequest` through `Client.request/3` as a bounded stream.
+  The response accumulates `SecDefOptParameter` protos and ends with a
+  `SecDefOptParameterEnd` marker.
+
+  Returns `{:ok, [%Proto.SecDefOptParameter{}, ...]}` on success (accumulated list),
+  or `{:error, reason}` on failure.
+
+  ## Options
+
+  * `:fut_fop_exchange` - Exchange for futures options (default: `""`)
+  * `:timeout` - Request timeout in milliseconds (default: `5_000`)
+
+  ## Examples
+
+      {:ok, params} = Options.sec_def_params(client, "AAPL", "STK", 265598)
+
+  """
+  @spec sec_def_params(pid(), String.t(), String.t(), integer(), keyword()) ::
+          {:ok, list()} | {:error, any()}
+  def sec_def_params(client, underlying_symbol, underlying_sec_type, underlying_con_id, opts \\ [])
+      when is_integer(underlying_con_id) do
+    request = %Proto.SecDefOptParamsRequest{
+      underlying_symbol: underlying_symbol,
+      fut_fop_exchange: Keyword.get(opts, :fut_fop_exchange, ""),
+      underlying_sec_type: underlying_sec_type,
+      underlying_con_id: underlying_con_id
+    }
+
+    Client.request(client, request, opts)
+  end
+end

--- a/test/ib_ex/client/options_test.exs
+++ b/test/ib_ex/client/options_test.exs
@@ -1,0 +1,395 @@
+defmodule IbEx.Client.OptionsTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.Options
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
+  @tick_option_computation_wire_id 221
+  @sec_def_opt_parameter_wire_id 275
+  @sec_def_opt_parameter_end_wire_id 276
+  @error_message_wire_id 204
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_client do
+    {:ok, pid} = Client.start_link(connection_handler: MockConnection)
+    pid
+  end
+
+  defp sample_contract do
+    %Proto.Contract{symbol: "AAPL", sec_type: "OPT", currency: "USD", exchange: "SMART"}
+  end
+
+  describe "implied_volatility/5" do
+    test "subscribes to implied volatility calculations and receives TickOptionComputation messages" do
+      client = start_client()
+
+      {:ok, ref} = Options.implied_volatility(client, sample_contract(), 10.50, 155.0)
+      assert is_reference(ref)
+
+      tick = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 13,
+        tick_attrib: 0,
+        implied_vol: 0.2534,
+        delta: 0.65,
+        opt_price: 10.50,
+        pv_dividend: 0.12,
+        gamma: 0.045,
+        vega: 0.32,
+        theta: -0.08,
+        und_price: 155.0
+      }
+
+      Client.process_message(client, wire_message(@tick_option_computation_wire_id, tick))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickOptionComputation{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.tick_type == 13
+      assert received.implied_vol == 0.2534
+      assert received.delta == 0.65
+      assert received.opt_price == 10.50
+      assert received.pv_dividend == 0.12
+      assert received.gamma == 0.045
+      assert received.vega == 0.32
+      assert received.theta == -0.08
+      assert received.und_price == 155.0
+    end
+
+    test "receives multiple TickOptionComputation updates on the same subscription" do
+      client = start_client()
+
+      {:ok, ref} = Options.implied_volatility(client, sample_contract(), 10.50, 155.0)
+
+      tick_1 = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 13,
+        implied_vol: 0.2534,
+        delta: 0.65,
+        opt_price: 10.50,
+        und_price: 155.0
+      }
+
+      tick_2 = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 13,
+        implied_vol: 0.2580,
+        delta: 0.66,
+        opt_price: 10.75,
+        und_price: 155.5
+      }
+
+      Client.process_message(client, wire_message(@tick_option_computation_wire_id, tick_1))
+      Client.process_message(client, wire_message(@tick_option_computation_wire_id, tick_2))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickOptionComputation{implied_vol: 0.2534, delta: 0.65}}, 1_000
+      assert_receive {:ib_ex, ^ref, %Proto.TickOptionComputation{implied_vol: 0.2580, delta: 0.66}}, 1_000
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+
+      {:ok, ref} = Options.implied_volatility(client, sample_contract(), 10.50, 155.0)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+  end
+
+  describe "cancel_implied_volatility/2" do
+    test "cancels an active implied volatility subscription" do
+      client = start_client()
+
+      {:ok, ref} = Options.implied_volatility(client, sample_contract(), 10.50, 155.0)
+      assert :ok = Options.cancel_implied_volatility(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = Options.cancel_implied_volatility(client, fake_ref)
+    end
+  end
+
+  describe "option_price/5" do
+    test "subscribes to option price calculations and receives TickOptionComputation messages" do
+      client = start_client()
+
+      {:ok, ref} = Options.option_price(client, sample_contract(), 0.25, 155.0)
+      assert is_reference(ref)
+
+      tick = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 13,
+        tick_attrib: 0,
+        implied_vol: 0.25,
+        delta: 0.62,
+        opt_price: 9.85,
+        pv_dividend: 0.12,
+        gamma: 0.042,
+        vega: 0.30,
+        theta: -0.07,
+        und_price: 155.0
+      }
+
+      Client.process_message(client, wire_message(@tick_option_computation_wire_id, tick))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickOptionComputation{} = received}, 1_000
+      assert received.req_id == 1
+      assert received.tick_type == 13
+      assert received.implied_vol == 0.25
+      assert received.delta == 0.62
+      assert received.opt_price == 9.85
+      assert received.pv_dividend == 0.12
+      assert received.gamma == 0.042
+      assert received.vega == 0.30
+      assert received.theta == -0.07
+      assert received.und_price == 155.0
+    end
+
+    test "receives multiple TickOptionComputation updates on the same subscription" do
+      client = start_client()
+
+      {:ok, ref} = Options.option_price(client, sample_contract(), 0.25, 155.0)
+
+      tick_1 = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 13,
+        implied_vol: 0.25,
+        delta: 0.62,
+        opt_price: 9.85,
+        und_price: 155.0
+      }
+
+      tick_2 = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 13,
+        implied_vol: 0.25,
+        delta: 0.63,
+        opt_price: 10.10,
+        und_price: 155.5
+      }
+
+      Client.process_message(client, wire_message(@tick_option_computation_wire_id, tick_1))
+      Client.process_message(client, wire_message(@tick_option_computation_wire_id, tick_2))
+
+      assert_receive {:ib_ex, ^ref, %Proto.TickOptionComputation{opt_price: 9.85, delta: 0.62}}, 1_000
+      assert_receive {:ib_ex, ^ref, %Proto.TickOptionComputation{opt_price: 10.10, delta: 0.63}}, 1_000
+    end
+
+    test "receives error messages for the subscription" do
+      client = start_client()
+
+      {:ok, ref} = Options.option_price(client, sample_contract(), 0.25, 155.0)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert_receive {:ib_ex, ^ref, {:error, %IbEx.Client.Types.Error{} = error}}, 1_000
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+  end
+
+  describe "cancel_option_price/2" do
+    test "cancels an active option price subscription" do
+      client = start_client()
+
+      {:ok, ref} = Options.option_price(client, sample_contract(), 0.25, 155.0)
+      assert :ok = Options.cancel_option_price(client, ref)
+    end
+
+    test "returns error for unknown subscription ref" do
+      client = start_client()
+      fake_ref = make_ref()
+
+      assert {:error, :not_found} = Options.cancel_option_price(client, fake_ref)
+    end
+  end
+
+  describe "sec_def_params/5" do
+    test "accumulates SecDefOptParameter responses and returns {:ok, list} on SecDefOptParameterEnd" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Options.sec_def_params(client, "AAPL", "STK", 265_598, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      param_1 = %Proto.SecDefOptParameter{
+        req_id: 1,
+        exchange: "SMART",
+        underlying_con_id: 265_598,
+        trading_class: "AAPL",
+        multiplier: "100",
+        expirations: ["20250117", "20250221"],
+        strikes: [140.0, 145.0, 150.0, 155.0, 160.0]
+      }
+
+      param_2 = %Proto.SecDefOptParameter{
+        req_id: 1,
+        exchange: "CBOE",
+        underlying_con_id: 265_598,
+        trading_class: "AAPL",
+        multiplier: "100",
+        expirations: ["20250117"],
+        strikes: [145.0, 150.0, 155.0]
+      }
+
+      Client.process_message(client, wire_message(@sec_def_opt_parameter_wire_id, param_1))
+      Client.process_message(client, wire_message(@sec_def_opt_parameter_wire_id, param_2))
+
+      end_marker = %Proto.SecDefOptParameterEnd{req_id: 1}
+      Client.process_message(client, wire_message(@sec_def_opt_parameter_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 2
+
+      [first, second] = results
+      assert %Proto.SecDefOptParameter{} = first
+      assert first.req_id == 1
+      assert first.exchange == "SMART"
+      assert first.underlying_con_id == 265_598
+      assert first.trading_class == "AAPL"
+      assert first.multiplier == "100"
+      assert first.expirations == ["20250117", "20250221"]
+      assert first.strikes == [140.0, 145.0, 150.0, 155.0, 160.0]
+
+      assert %Proto.SecDefOptParameter{} = second
+      assert second.exchange == "CBOE"
+      assert second.expirations == ["20250117"]
+      assert second.strikes == [145.0, 150.0, 155.0]
+    end
+
+    test "returns {:ok, []} when no option parameters exist" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Options.sec_def_params(client, "AAPL", "STK", 265_598, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      end_marker = %Proto.SecDefOptParameterEnd{req_id: 1}
+      Client.process_message(client, wire_message(@sec_def_opt_parameter_end_wire_id, end_marker))
+
+      assert {:ok, []} = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, error} when TWS sends ErrorMessage for the req_id" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Options.sec_def_params(client, "INVALID", "STK", 0, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      error_proto = %Proto.ErrorMessage{
+        id: 1,
+        error_code: 200,
+        error_msg: "No security definition has been found for the request"
+      }
+
+      Client.process_message(client, wire_message(@error_message_wire_id, error_proto))
+
+      assert {:error, error} = Task.await(task, 5_000)
+      assert %IbEx.Client.Types.Error{} = error
+      assert error.id == 1
+      assert error.code == 200
+      assert error.message == "No security definition has been found for the request"
+    end
+
+    test "returns {:error, :timeout} when no response arrives within the timeout window" do
+      client = start_client()
+
+      result =
+        try do
+          Options.sec_def_params(client, "AAPL", "STK", 265_598, timeout: 100)
+        catch
+          :exit, {:timeout, _} -> {:error, :timeout}
+        end
+
+      assert {:error, :timeout} = result
+    end
+
+    test "passes fut_fop_exchange option to the request" do
+      client = start_client()
+
+      task =
+        Task.async(fn ->
+          Options.sec_def_params(client, "ES", "FUT", 551_601_561, fut_fop_exchange: "CME", timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      param = %Proto.SecDefOptParameter{
+        req_id: 1,
+        exchange: "CME",
+        underlying_con_id: 551_601_561,
+        trading_class: "ES",
+        multiplier: "50",
+        expirations: ["20250321"],
+        strikes: [5000.0, 5100.0, 5200.0]
+      }
+
+      Client.process_message(client, wire_message(@sec_def_opt_parameter_wire_id, param))
+
+      end_marker = %Proto.SecDefOptParameterEnd{req_id: 1}
+      Client.process_message(client, wire_message(@sec_def_opt_parameter_end_wire_id, end_marker))
+
+      assert {:ok, results} = Task.await(task, 5_000)
+      assert length(results) == 1
+
+      [result] = results
+      assert result.exchange == "CME"
+      assert result.trading_class == "ES"
+      assert result.multiplier == "50"
+      assert result.strikes == [5000.0, 5100.0, 5200.0]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Client.Options` thematic module with `implied_volatility/5`, `cancel_implied_volatility/2`, `option_price/5`, `cancel_option_price/2`, and `sec_def_params/5`
- Follows existing patterns from Client.News, Client.Account, Client.Scanner
- Supports stream subscriptions for implied vol/option price and bounded streams for sec_def_params

## Test plan
- [x] 15 new tests covering subscriptions, cancellations, error handling, bounded streams, timeouts
- [x] All 544 tests pass
- [x] Clean compile with `--warnings-as-errors`

vtb: d7d54ae6-8072-4db1-9d71-75ad24c1166f