### PR TITLE
Parse trading_hours and liquid_hours into structured domain types

### DIFF
--- a/lib/ib_ex/client/types/contract_details.ex
+++ b/lib/ib_ex/client/types/contract_details.ex
@@ -5,6 +5,8 @@ defmodule IbEx.Client.Types.ContractDetails do
 
   alias IbEx.Client.Types.Contract
   alias IbEx.Client.Types.TagValue
+  alias IbEx.Client.Types.TradingSchedule
+  alias IbEx.Client.Types.TradingSession
 
   alias IbEx.Client.Types.ContractDetails.{
     BondDetails,
@@ -25,8 +27,8 @@ defmodule IbEx.Client.Types.ContractDetails do
             category: nil,
             subcategory: nil,
             time_zone_id: nil,
-            trading_hours: nil,
-            liquid_hours: nil,
+            trading_hours: [],
+            liquid_hours: [],
             ev_rule: nil,
             ev_multiplier: 0.0,
             agg_group: 0,
@@ -60,8 +62,8 @@ defmodule IbEx.Client.Types.ContractDetails do
           category: binary() | nil,
           subcategory: binary() | nil,
           time_zone_id: binary() | nil,
-          trading_hours: binary() | nil,
-          liquid_hours: binary() | nil,
+          trading_hours: list(TradingSession.t()),
+          liquid_hours: list(TradingSession.t()),
           ev_rule: binary() | nil,
           ev_multiplier: float(),
           agg_group: non_neg_integer(),
@@ -96,6 +98,8 @@ defmodule IbEx.Client.Types.ContractDetails do
       |> assign_params(:bond_details, BondDetails)
       |> assign_params(:fund_details, FundDetails)
       |> assign_params(:event_contract, EventContract)
+      |> parse_schedule(:trading_hours)
+      |> parse_schedule(:liquid_hours)
 
     struct(__MODULE__, attrs)
   end
@@ -117,6 +121,13 @@ defmodule IbEx.Client.Types.ContractDetails do
       value when is_binary(value) -> Map.put(attrs, key, String.split(value, ",", trim: true))
       value when is_list(value) -> Map.put(attrs, key, value)
       _ -> Map.put(attrs, key, [])
+    end
+  end
+
+  defp parse_schedule(attrs, key) do
+    case Map.get(attrs, key) do
+      value when is_binary(value) -> Map.put(attrs, key, TradingSchedule.parse(value))
+      _ -> attrs
     end
   end
 end

--- a/lib/ib_ex/client/types/trading_schedule.ex
+++ b/lib/ib_ex/client/types/trading_schedule.ex
@@ -1,0 +1,42 @@
+defmodule IbEx.Client.Types.TradingSchedule do
+  @moduledoc """
+  Parses a semicolon-delimited trading hours or liquid hours string from
+  ContractDetails into a list of `TradingSession` structs.
+
+  Format: `"20260208:CLOSED;20260209:0400-20260209:2000;20260210:0400-20260210:2000"`
+  """
+
+  alias IbEx.Client.Types.TradingSession
+
+  @doc """
+  Parses a semicolon-delimited schedule string into a list of TradingSession structs.
+
+  Returns an empty list for nil or empty string input.
+
+  ## Examples
+
+      iex> TradingSchedule.parse("20260208:CLOSED;20260209:0400-20260209:2000")
+      [
+        %TradingSession{date: ~D[2026-02-08], status: :closed, open: nil, close: nil},
+        %TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[04:00:00], close: ~T[20:00:00]}
+      ]
+
+      iex> TradingSchedule.parse(nil)
+      []
+  """
+  @spec parse(binary() | nil) :: list(TradingSession.t())
+  def parse(nil), do: []
+  def parse(""), do: []
+
+  def parse(schedule) when is_binary(schedule) do
+    schedule
+    |> String.split(";", trim: true)
+    |> Enum.reduce([], fn entry, acc ->
+      case TradingSession.parse(entry) do
+        {:ok, session} -> [session | acc]
+        {:error, _} -> acc
+      end
+    end)
+    |> Enum.reverse()
+  end
+end

--- a/lib/ib_ex/client/types/trading_session.ex
+++ b/lib/ib_ex/client/types/trading_session.ex
@@ -1,0 +1,85 @@
+defmodule IbEx.Client.Types.TradingSession do
+  @moduledoc """
+  Represents a single trading session entry parsed from the trading_hours or
+  liquid_hours string on ContractDetails.
+
+  Each entry in the semicolon-delimited string is either:
+  - A closed day: `"20260208:CLOSED"`
+  - A time range: `"20260209:0400-20260209:2000"`
+
+  The timezone is not stored here -- it lives on `ContractDetails.time_zone_id`.
+  """
+
+  defstruct date: nil,
+            status: nil,
+            open: nil,
+            close: nil
+
+  @type t :: %__MODULE__{
+          date: Date.t() | nil,
+          status: :open | :closed,
+          open: Time.t() | nil,
+          close: Time.t() | nil
+        }
+
+  @doc """
+  Parses a single trading session entry string.
+
+  ## Examples
+
+      iex> TradingSession.parse("20260208:CLOSED")
+      {:ok, %TradingSession{date: ~D[2026-02-08], status: :closed, open: nil, close: nil}}
+
+      iex> TradingSession.parse("20260209:0400-20260209:2000")
+      {:ok, %TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[04:00:00], close: ~T[20:00:00]}}
+  """
+  @spec parse(binary()) :: {:ok, t()} | {:error, :invalid_format}
+  def parse(<<date::binary-size(8), ":CLOSED">>) do
+    with {:ok, date} <- parse_date(date) do
+      {:ok, %__MODULE__{date: date, status: :closed}}
+    end
+  end
+
+  def parse(<<open_part::binary-size(13), "-", close_part::binary-size(13)>>) do
+    with {:ok, open_date, open_time} <- parse_datetime(open_part),
+         {:ok, _close_date, close_time} <- parse_datetime(close_part) do
+      {:ok, %__MODULE__{date: open_date, status: :open, open: open_time, close: close_time}}
+    end
+  end
+
+  def parse(entry) when is_binary(entry), do: {:error, :invalid_format}
+
+  def parse(_), do: {:error, :invalid_format}
+
+  defp parse_date(<<year::binary-size(4), month::binary-size(2), day::binary-size(2)>>) do
+    with {y, ""} <- Integer.parse(year),
+         {m, ""} <- Integer.parse(month),
+         {d, ""} <- Integer.parse(day) do
+      Date.new(y, m, d)
+    else
+      _ -> {:error, :invalid_format}
+    end
+  end
+
+  defp parse_date(_), do: {:error, :invalid_format}
+
+  defp parse_datetime(<<date::binary-size(8), ":", time::binary-size(4)>>) do
+    with {:ok, date} <- parse_date(date),
+         {:ok, time} <- parse_time(time) do
+      {:ok, date, time}
+    end
+  end
+
+  defp parse_datetime(_), do: {:error, :invalid_format}
+
+  defp parse_time(<<hour::binary-size(2), minute::binary-size(2)>>) do
+    with {h, ""} <- Integer.parse(hour),
+         {m, ""} <- Integer.parse(minute) do
+      Time.new(h, m, 0)
+    else
+      _ -> {:error, :invalid_format}
+    end
+  end
+
+  defp parse_time(_), do: {:error, :invalid_format}
+end

--- a/test/ib_ex/client/types/contract_details_test.exs
+++ b/test/ib_ex/client/types/contract_details_test.exs
@@ -2,6 +2,7 @@ defmodule IbEx.Client.Types.ContractDetailsTest do
   use ExUnit.Case, async: true
 
   alias IbEx.Client.Types.ContractDetails
+  alias IbEx.Client.Types.TradingSession
 
   describe "new/1 valid_exchanges parsing" do
     test "parses comma-separated valid_exchanges string into a list of strings" do
@@ -82,6 +83,75 @@ defmodule IbEx.Client.Types.ContractDetailsTest do
 
       assert details.valid_exchanges == []
       assert details.order_types == []
+    end
+
+    test "creates a ContractDetails struct with empty lists for trading_hours and liquid_hours" do
+      result = ContractDetails.new()
+
+      assert result.trading_hours == []
+      assert result.liquid_hours == []
+    end
+  end
+
+  describe "new/1 parses trading_hours and liquid_hours" do
+    test "parses trading_hours string into list of TradingSession structs" do
+      attrs = %{
+        trading_hours: "20260208:CLOSED;20260209:0400-20260209:2000"
+      }
+
+      result = ContractDetails.new(attrs)
+
+      assert length(result.trading_hours) == 2
+
+      assert [closed_session, open_session] = result.trading_hours
+      assert %TradingSession{date: ~D[2026-02-08], status: :closed, open: nil, close: nil} = closed_session
+
+      assert %TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[04:00:00], close: ~T[20:00:00]} =
+               open_session
+    end
+
+    test "parses liquid_hours string into list of TradingSession structs" do
+      attrs = %{
+        liquid_hours: "20260208:CLOSED;20260209:0930-20260209:1600"
+      }
+
+      result = ContractDetails.new(attrs)
+
+      assert length(result.liquid_hours) == 2
+
+      assert [closed_session, open_session] = result.liquid_hours
+      assert %TradingSession{date: ~D[2026-02-08], status: :closed} = closed_session
+
+      assert %TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[09:30:00], close: ~T[16:00:00]} =
+               open_session
+    end
+
+    test "parses both trading_hours and liquid_hours from keyword list" do
+      attrs = [
+        trading_hours: "20260209:0400-20260209:2000",
+        liquid_hours: "20260209:0930-20260209:1600"
+      ]
+
+      result = ContractDetails.new(attrs)
+
+      assert [%TradingSession{status: :open, open: ~T[04:00:00], close: ~T[20:00:00]}] = result.trading_hours
+      assert [%TradingSession{status: :open, open: ~T[09:30:00], close: ~T[16:00:00]}] = result.liquid_hours
+    end
+
+    test "leaves trading_hours as empty list when not provided" do
+      result = ContractDetails.new(%{market_name: "NMS"})
+
+      assert result.trading_hours == []
+      assert result.liquid_hours == []
+    end
+
+    test "preserves already-parsed list of TradingSession structs" do
+      sessions = [%TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[04:00:00], close: ~T[20:00:00]}]
+      attrs = %{trading_hours: sessions}
+
+      result = ContractDetails.new(attrs)
+
+      assert result.trading_hours == sessions
     end
   end
 end

--- a/test/ib_ex/client/types/trading_schedule_test.exs
+++ b/test/ib_ex/client/types/trading_schedule_test.exs
@@ -1,0 +1,59 @@
+defmodule IbEx.Client.Types.TradingScheduleTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.TradingSchedule
+  alias IbEx.Client.Types.TradingSession
+
+  describe "parse/1 with a full schedule string" do
+    test "parses semicolon-delimited string into list of TradingSession structs" do
+      schedule = "20260208:CLOSED;20260209:0400-20260209:2000;20260210:0400-20260210:2000"
+
+      result = TradingSchedule.parse(schedule)
+
+      assert length(result) == 3
+
+      assert [closed_day, open_day_1, open_day_2] = result
+
+      assert %TradingSession{date: ~D[2026-02-08], status: :closed, open: nil, close: nil} = closed_day
+
+      assert %TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[04:00:00], close: ~T[20:00:00]} =
+               open_day_1
+
+      assert %TradingSession{date: ~D[2026-02-10], status: :open, open: ~T[04:00:00], close: ~T[20:00:00]} =
+               open_day_2
+    end
+
+    test "parses a single CLOSED entry" do
+      result = TradingSchedule.parse("20260208:CLOSED")
+
+      assert [%TradingSession{date: ~D[2026-02-08], status: :closed}] = result
+    end
+
+    test "parses a single open entry" do
+      result = TradingSchedule.parse("20260209:0930-20260209:1600")
+
+      assert [%TradingSession{date: ~D[2026-02-09], status: :open, open: ~T[09:30:00], close: ~T[16:00:00]}] = result
+    end
+  end
+
+  describe "parse/1 with nil or empty input" do
+    test "returns empty list for nil" do
+      assert TradingSchedule.parse(nil) == []
+    end
+
+    test "returns empty list for empty string" do
+      assert TradingSchedule.parse("") == []
+    end
+  end
+
+  describe "parse/1 skips invalid entries" do
+    test "skips entries that fail to parse" do
+      schedule = "20260208:CLOSED;invalid;20260209:0400-20260209:2000"
+
+      result = TradingSchedule.parse(schedule)
+
+      assert length(result) == 2
+      assert [%TradingSession{status: :closed}, %TradingSession{status: :open}] = result
+    end
+  end
+end

--- a/test/ib_ex/client/types/trading_session_test.exs
+++ b/test/ib_ex/client/types/trading_session_test.exs
@@ -1,0 +1,78 @@
+defmodule IbEx.Client.Types.TradingSessionTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client.Types.TradingSession
+
+  describe "parse/1 with CLOSED entries" do
+    test "parses a CLOSED entry into a closed session" do
+      assert {:ok, session} = TradingSession.parse("20260208:CLOSED")
+
+      assert session.date == ~D[2026-02-08]
+      assert session.status == :closed
+      assert session.open == nil
+      assert session.close == nil
+    end
+
+    test "parses a different CLOSED date" do
+      assert {:ok, session} = TradingSession.parse("20260101:CLOSED")
+
+      assert session.date == ~D[2026-01-01]
+      assert session.status == :closed
+    end
+  end
+
+  describe "parse/1 with time-range entries" do
+    test "parses a time-range entry into an open session" do
+      assert {:ok, session} = TradingSession.parse("20260209:0400-20260209:2000")
+
+      assert session.date == ~D[2026-02-09]
+      assert session.status == :open
+      assert session.open == ~T[04:00:00]
+      assert session.close == ~T[20:00:00]
+    end
+
+    test "parses a session with midnight boundaries" do
+      assert {:ok, session} = TradingSession.parse("20260210:0000-20260210:2359")
+
+      assert session.date == ~D[2026-02-10]
+      assert session.status == :open
+      assert session.open == ~T[00:00:00]
+      assert session.close == ~T[23:59:00]
+    end
+
+    test "parses a session spanning different dates" do
+      assert {:ok, session} = TradingSession.parse("20260209:1700-20260210:1700")
+
+      assert session.date == ~D[2026-02-09]
+      assert session.status == :open
+      assert session.open == ~T[17:00:00]
+      assert session.close == ~T[17:00:00]
+    end
+  end
+
+  describe "parse/1 with invalid input" do
+    test "returns error for empty string" do
+      assert {:error, :invalid_format} = TradingSession.parse("")
+    end
+
+    test "returns error for arbitrary string" do
+      assert {:error, :invalid_format} = TradingSession.parse("not-a-session")
+    end
+
+    test "returns error for non-binary input" do
+      assert {:error, :invalid_format} = TradingSession.parse(123)
+    end
+
+    test "returns error for nil input" do
+      assert {:error, :invalid_format} = TradingSession.parse(nil)
+    end
+
+    test "returns error for malformed date in CLOSED entry" do
+      assert {:error, _} = TradingSession.parse("99999999:CLOSED")
+    end
+
+    test "returns error for malformed time in range entry" do
+      assert {:error, _} = TradingSession.parse("20260209:9999-20260209:2000")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `TradingSession` struct with date, status (:open/:closed), open time, close time
- Add `TradingSchedule.parse/1` to split semicolon-delimited strings into `TradingSession` lists
- Parse `trading_hours` and `liquid_hours` in `ContractDetails.new/1` from raw strings into structured types
- Default values changed from `nil` to `[]`

## Test plan
- [x] Unit tests for TradingSession.parse/1 (CLOSED, time-range, invalid input)
- [x] Unit tests for TradingSchedule.parse/1 (full schedules, nil/empty, invalid entries)
- [x] Integration tests for ContractDetails parsing
- [x] All 552 tests pass
- [x] Clean compile with `--warnings-as-errors`

vtb: ce7f8758-728e-41c2-bf1a-a2bbbf1127bf