### PR TITLE
Track NextValidId and use it for order placement

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -16,7 +16,7 @@ defmodule IbEx.Client do
   After the `InitConnection.Response` is received then we send the `StartApi.Request` message
   which the TWS server replies with:
   * Account number
-  * Next valid ID (presumably for order placement)
+  * Next valid ID (used as the order ID sequence for order placement)
   * Info messages regarding which data farms are connected
 
   """
@@ -71,6 +71,13 @@ defmodule IbEx.Client do
 
   def command(pid, proto_msg) do
     GenServer.call(pid, {:command, proto_msg})
+  end
+
+  @doc """
+  Returns the current next valid order ID tracked by the Client.
+  """
+  def next_valid_id(pid) do
+    GenServer.call(pid, :next_valid_id)
   end
 
   def start_link(opts \\ []) do
@@ -194,10 +201,13 @@ defmodule IbEx.Client do
   end
 
   def handle_call({:subscribe, subscriber, %message_type{} = proto_msg, _opts}, _from, state) do
-    case Conversations.register_stream(state.subscriptions_table_ref, message_type, subscriber) do
+    next_valid_id = order_id_for_correlation(message_type, state)
+
+    case Conversations.register_stream(state.subscriptions_table_ref, message_type, subscriber, next_valid_id) do
       {:ok, req_id, subscription_ref} ->
         proto_msg = set_correlation_id(message_type, proto_msg, req_id)
         send_to_tws(state, proto_msg)
+        maybe_request_next_valid_id(message_type, state)
         {:reply, {:ok, subscription_ref}, state}
 
       :error ->
@@ -221,6 +231,10 @@ defmodule IbEx.Client do
   def handle_call({:command, proto_msg}, _from, state) do
     send_to_tws(state, proto_msg)
     {:reply, :ok, state}
+  end
+
+  def handle_call(:next_valid_id, _from, state) do
+    {:reply, state.next_valid_id, state}
   end
 
   def handle_info({:request_timeout, key}, state) do
@@ -300,6 +314,23 @@ defmodule IbEx.Client do
     end
 
     Subscriptions.remove_subscription(table_ref, key)
+  end
+
+  defp order_id_for_correlation(message_type, state) do
+    case Conversations.conversation_for(message_type) do
+      {:ok, %{correlation: :order_id}} -> state.next_valid_id
+      _ -> nil
+    end
+  end
+
+  defp maybe_request_next_valid_id(message_type, state) do
+    case Conversations.conversation_for(message_type) do
+      {:ok, %{correlation: :order_id}} ->
+        send_to_tws(state, %IbEx.Client.Proto.Protobuf.IdsRequest{num_ids: 1})
+
+      _ ->
+        :ok
+    end
   end
 
   defp set_correlation_id(message_type, proto_msg, id) do

--- a/lib/ib_ex/client/conversations.ex
+++ b/lib/ib_ex/client/conversations.ex
@@ -520,14 +520,19 @@ defmodule IbEx.Client.Conversations do
   Validates the conversation is a `:stream` type, allocates a req_id,
   monitors the subscriber process, and registers the stream entry via Subscriptions.
 
+  For `:order_id` correlated streams (e.g. PlaceOrderRequest), an explicit
+  `next_valid_id` must be supplied so the Client's TWS-assigned order ID
+  sequence is used instead of the generic ETS counter.
+
   Returns `{:ok, req_id, subscription_ref}` on success or `:error` if the
   request module is not a registered stream conversation.
   """
-  @spec register_stream(reference(), module(), pid()) :: {:ok, non_neg_integer(), reference()} | :error
-  def register_stream(table_ref, request_module, subscriber) do
+  @spec register_stream(reference(), module(), pid(), integer() | nil) ::
+          {:ok, non_neg_integer(), reference()} | :error
+  def register_stream(table_ref, request_module, subscriber, next_valid_id \\ nil) do
     case conversation_for(request_module) do
       {:ok, %{type: :stream, correlation: correlation}} ->
-        {key, req_id} = build_stream_key(correlation, table_ref, request_module)
+        {key, req_id} = build_key(correlation, table_ref, request_module, next_valid_id)
 
         subscription_ref = make_ref()
         monitor_ref = Process.monitor(subscriber)
@@ -540,32 +545,22 @@ defmodule IbEx.Client.Conversations do
     end
   end
 
-  defp build_stream_key(:global, _table_ref, request_module) do
-    {{:global, request_module}, nil}
-  end
+  defp build_key(correlation, table_ref, request_module, next_valid_id \\ nil) do
+    case correlation do
+      :global ->
+        {{:global, request_module}, nil}
 
-  defp build_stream_key(:order_id, table_ref, _request_module) do
-    req_id = Subscriptions.allocate_request_id(table_ref)
-    {{:order_id, req_id}, req_id}
-  end
+      :order_id when is_integer(next_valid_id) ->
+        {{:order_id, next_valid_id}, next_valid_id}
 
-  defp build_stream_key(_correlation, table_ref, _request_module) do
-    req_id = Subscriptions.allocate_request_id(table_ref)
-    {{:request_id, req_id}, req_id}
-  end
+      :order_id ->
+        req_id = Subscriptions.allocate_request_id(table_ref)
+        {{:order_id, req_id}, req_id}
 
-  defp build_key(:req_id, table_ref, _request_module) do
-    req_id = Subscriptions.allocate_request_id(table_ref)
-    {{:request_id, req_id}, req_id}
-  end
-
-  defp build_key(:global, _table_ref, request_module) do
-    {{:global, request_module}, nil}
-  end
-
-  defp build_key(:order_id, table_ref, _request_module) do
-    req_id = Subscriptions.allocate_request_id(table_ref)
-    {{:order_id, req_id}, req_id}
+      _ ->
+        req_id = Subscriptions.allocate_request_id(table_ref)
+        {{:request_id, req_id}, req_id}
+    end
   end
 
   defp end_markers do

--- a/test/ib_ex/client/conversations_test.exs
+++ b/test/ib_ex/client/conversations_test.exs
@@ -466,6 +466,42 @@ defmodule IbEx.Client.ConversationsTest do
       assert is_reference(entry.monitor_ref)
     end
 
+    test "registers an order_id stream with explicit next_valid_id", %{table_ref: table_ref} do
+      assert {:ok, order_id, subscription_ref} =
+               Conversations.register_stream(table_ref, Proto.PlaceOrderRequest, self(), 42)
+
+      assert order_id == 42
+      assert is_reference(subscription_ref)
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, {:order_id, 42})
+      assert entry.type == :stream
+      assert entry.subscriber == self()
+      assert entry.subscription_ref == subscription_ref
+      assert entry.request_module == Proto.PlaceOrderRequest
+    end
+
+    test "order_id stream falls back to ETS counter when next_valid_id is nil", %{table_ref: table_ref} do
+      assert {:ok, order_id, subscription_ref} =
+               Conversations.register_stream(table_ref, Proto.PlaceOrderRequest, self(), nil)
+
+      assert order_id == 1
+      assert is_reference(subscription_ref)
+
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, {:order_id, 1})
+      assert entry.type == :stream
+      assert entry.request_module == Proto.PlaceOrderRequest
+    end
+
+    test "next_valid_id is ignored for non-order_id correlated streams", %{table_ref: table_ref} do
+      assert {:ok, req_id, _subscription_ref} =
+               Conversations.register_stream(table_ref, Proto.MarketDataRequest, self(), 999)
+
+      # Should use ETS counter (1), not the passed next_valid_id (999)
+      assert req_id == 1
+      assert {:ok, _} = Subscriptions.lookup(table_ref, {:request_id, 1})
+      assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, {:order_id, 999})
+    end
+
     test "returns :error for non-stream conversation types", %{table_ref: table_ref} do
       assert :error = Conversations.register_stream(table_ref, Proto.MatchingSymbolsRequest, self())
       assert :error = Conversations.register_stream(table_ref, Proto.ContractDataRequest, self())

--- a/test/ib_ex/client/orders_test.exs
+++ b/test/ib_ex/client/orders_test.exs
@@ -25,6 +25,50 @@ defmodule IbEx.Client.OrdersTest do
     def handle_call(_, _, state), do: {:reply, :ok, state}
   end
 
+  defmodule RecordingConnection do
+    @moduledoc false
+    use GenServer
+
+    @agent_name __MODULE__.TestPidAgent
+
+    def set_test_pid(pid) do
+      case Agent.start_link(fn -> pid end, name: @agent_name) do
+        {:ok, _} ->
+          :ok
+
+        {:error, {:already_started, agent_pid}} ->
+          Agent.update(agent_pid, fn _ -> pid end)
+          :ok
+      end
+    end
+
+    defp get_test_pid do
+      try do
+        Agent.get(@agent_name, & &1)
+      catch
+        :exit, _ -> nil
+      end
+    end
+
+    def start_link(opts) do
+      test_pid = get_test_pid()
+      GenServer.start_link(__MODULE__, %{test_pid: test_pid, client: Keyword.fetch!(opts, :client)})
+    end
+
+    def send_message(pid, msg) do
+      GenServer.call(pid, {:send_message, msg})
+    end
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call({:send_message, msg}, _from, state) do
+      if state.test_pid, do: send(state.test_pid, {:tws_sent, msg})
+      {:reply, :ok, state}
+    end
+  end
+
   # Wire format helpers: raw wire_id = msg_id + @protobuf_offset (200)
   @open_order_wire_id 205
   @open_orders_end_wire_id 253
@@ -40,6 +84,24 @@ defmodule IbEx.Client.OrdersTest do
   defp start_client do
     {:ok, pid} = Client.start_link(connection_handler: MockConnection)
     pid
+  end
+
+  defp start_client_with_next_valid_id(next_valid_id) do
+    client = start_client()
+    inject_next_valid_id(client, next_valid_id)
+    client
+  end
+
+  defp inject_next_valid_id(client, next_valid_id) do
+    # Simulate TWS sending a NextValidId during the handshake
+    proto_payload =
+      %Proto.NextValidId{order_id: next_valid_id}
+      |> Protobuf.encode()
+
+    wire_msg = <<209::big-integer-size(32), proto_payload::binary>>
+    Client.process_message(client, wire_msg)
+    # Small sleep to ensure the cast is processed
+    Process.sleep(20)
   end
 
   describe "open_orders/2" do
@@ -272,7 +334,7 @@ defmodule IbEx.Client.OrdersTest do
 
   describe "place/4" do
     test "subscribes to order lifecycle and receives OrderStatus messages" do
-      client = start_client()
+      client = start_client_with_next_valid_id(100)
 
       proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
       proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
@@ -280,9 +342,9 @@ defmodule IbEx.Client.OrdersTest do
       {:ok, ref} = Orders.place(client, proto_contract, proto_order)
       assert is_reference(ref)
 
-      # The allocated order_id should be 1 (first allocation)
+      # The allocated order_id should be 100 (from next_valid_id)
       order_status = %Proto.OrderStatus{
-        order_id: 1,
+        order_id: 100,
         status: "PreSubmitted",
         filled: "0",
         remaining: "100",
@@ -298,7 +360,7 @@ defmodule IbEx.Client.OrdersTest do
       Client.process_message(client, wire_message(@order_status_wire_id, order_status))
 
       assert_receive {:ib_ex, ^ref, %Proto.OrderStatus{} = received}, 1_000
-      assert received.order_id == 1
+      assert received.order_id == 100
       assert received.status == "PreSubmitted"
       assert received.filled == "0"
       assert received.remaining == "100"
@@ -306,7 +368,7 @@ defmodule IbEx.Client.OrdersTest do
     end
 
     test "receives OpenOrder messages through the subscription" do
-      client = start_client()
+      client = start_client_with_next_valid_id(100)
 
       proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
       proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
@@ -314,7 +376,7 @@ defmodule IbEx.Client.OrdersTest do
       {:ok, ref} = Orders.place(client, proto_contract, proto_order)
 
       open_order = %Proto.OpenOrder{
-        order_id: 1,
+        order_id: 100,
         contract: %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"},
         order: %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0},
         order_state: %Proto.OrderState{status: "PreSubmitted"}
@@ -323,13 +385,13 @@ defmodule IbEx.Client.OrdersTest do
       Client.process_message(client, wire_message(@open_order_wire_id, open_order))
 
       assert_receive {:ib_ex, ^ref, %Proto.OpenOrder{} = received}, 1_000
-      assert received.order_id == 1
+      assert received.order_id == 100
       assert received.contract.symbol == "AAPL"
       assert received.order.action == "BUY"
     end
 
     test "receives OrderBound messages through the subscription" do
-      client = start_client()
+      client = start_client_with_next_valid_id(100)
 
       proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
       proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
@@ -337,7 +399,7 @@ defmodule IbEx.Client.OrdersTest do
       {:ok, ref} = Orders.place(client, proto_contract, proto_order)
 
       order_bound = %Proto.OrderBound{
-        order_id: 1,
+        order_id: 100,
         client_id: 0,
         perm_id: 98765
       }
@@ -345,12 +407,51 @@ defmodule IbEx.Client.OrdersTest do
       Client.process_message(client, wire_message(@order_bound_wire_id, order_bound))
 
       assert_receive {:ib_ex, ^ref, %Proto.OrderBound{} = received}, 1_000
-      assert received.order_id == 1
+      assert received.order_id == 100
       assert received.perm_id == 98765
     end
 
+    test "sends IdsRequest to TWS after placing an order" do
+      RecordingConnection.set_test_pid(self())
+      {:ok, client} = Client.start_link(connection_handler: RecordingConnection)
+      inject_next_valid_id(client, 42)
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+      proto_order = %Proto.Order{action: "BUY", total_quantity: "1", order_type: "LMT", lmt_price: 150.0}
+
+      {:ok, _ref} = Orders.place(client, proto_contract, proto_order)
+
+      # First message: the PlaceOrderRequest
+      assert_receive {:tws_sent, _place_order_msg}, 1_000
+
+      # Second message: IdsRequest to get the next valid order ID from TWS
+      assert_receive {:tws_sent, ids_request_msg}, 1_000
+      <<_wire_id::big-integer-size(32), payload::binary>> = ids_request_msg
+      decoded = Protobuf.decode(payload, Proto.IdsRequest)
+      assert decoded.num_ids == 1
+    end
+
+    test "sends the PlaceOrderRequest with order_id from next_valid_id" do
+      RecordingConnection.set_test_pid(self())
+      {:ok, client} = Client.start_link(connection_handler: RecordingConnection)
+      inject_next_valid_id(client, 42)
+
+      proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
+      proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
+
+      {:ok, _ref} = Orders.place(client, proto_contract, proto_order)
+
+      assert_receive {:tws_sent, wire_msg}, 1_000
+      <<_wire_id::big-integer-size(32), payload::binary>> = wire_msg
+      # PlaceOrderRequest wire_id = msg_id + 200
+      decoded = Protobuf.decode(payload, Proto.PlaceOrderRequest)
+      assert decoded.order_id == 42
+      assert decoded.contract.symbol == "AAPL"
+      assert decoded.order.action == "BUY"
+    end
+
     test "accepts domain contracts and proto orders" do
-      client = start_client()
+      client = start_client_with_next_valid_id(100)
 
       domain_contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
       proto_order = %Proto.Order{action: "BUY", total_quantity: "100", order_type: "LMT", lmt_price: 150.0}
@@ -360,7 +461,7 @@ defmodule IbEx.Client.OrdersTest do
     end
 
     test "accepts proto contracts and domain orders" do
-      client = start_client()
+      client = start_client_with_next_valid_id(100)
 
       proto_contract = %Proto.Contract{symbol: "AAPL", sec_type: "STK", currency: "USD"}
       domain_order = DomainOrder.new(%{action: "BUY", total_quantity: 100, order_type: "LMT", limit_price: 150.0})
@@ -370,7 +471,7 @@ defmodule IbEx.Client.OrdersTest do
     end
 
     test "accepts domain contracts and domain orders" do
-      client = start_client()
+      client = start_client_with_next_valid_id(100)
 
       domain_contract = %DomainContract{symbol: "AAPL", security_type: "STK", currency: "USD"}
       domain_order = DomainOrder.new(%{action: "BUY", total_quantity: 100, order_type: "LMT", limit_price: 150.0})

--- a/test/ib_ex/client_test.exs
+++ b/test/ib_ex/client_test.exs
@@ -603,4 +603,107 @@ defmodule IbEx.ClientTest do
       assert {:error, :missing_subscription} = Subscriptions.lookup(table_ref, global_key)
     end
   end
+
+  describe "next_valid_id/1" do
+    test "returns the current next_valid_id from state" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+
+      # Initially nil
+      assert {:reply, nil, ^state} = Client.handle_call(:next_valid_id, {self(), make_ref()}, state)
+
+      # After setting next_valid_id (simulating TWS handshake)
+      state_with_id = %{state | next_valid_id: 42}
+      assert {:reply, 42, ^state_with_id} = Client.handle_call(:next_valid_id, {self(), make_ref()}, state_with_id)
+    end
+  end
+
+  describe "subscribe/3 with order_id correlation" do
+    test "uses next_valid_id from state for order_id correlated streams" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      table_ref = state.subscriptions_table_ref
+      state = %{state | next_valid_id: 100}
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.PlaceOrderRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"},
+        order: %IbEx.Client.Proto.Protobuf.Order{action: "BUY", total_quantity: "100", order_type: "LMT"}
+      }
+
+      assert {:reply, {:ok, subscription_ref}, new_state} =
+               Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      assert is_reference(subscription_ref)
+
+      # Verify ETS entry was created with order_id key using next_valid_id
+      assert {:ok, entry} = Subscriptions.lookup(table_ref, {:order_id, 100})
+      assert entry.type == :stream
+      assert entry.subscriber == self()
+      assert entry.request_module == IbEx.Client.Proto.Protobuf.PlaceOrderRequest
+
+      # next_valid_id is not locally incremented; it waits for TWS to send a new NextValidId
+      assert new_state.next_valid_id == 100
+    end
+
+    test "does not change next_valid_id for req_id correlated streams" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      state = %{state | next_valid_id: 100}
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.MarketDataRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"}
+      }
+
+      {:reply, {:ok, _subscription_ref}, new_state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # next_valid_id should NOT have changed
+      assert new_state.next_valid_id == 100
+    end
+
+    test "order messages are delivered using the TWS-assigned order_id" do
+      {:ok, state} = Client.init(connection_handler: MockSuccessConnection)
+      state = %{state | next_valid_id: 200}
+
+      proto_msg = %IbEx.Client.Proto.Protobuf.PlaceOrderRequest{
+        contract: %IbEx.Client.Proto.Protobuf.Contract{symbol: "AAPL"},
+        order: %IbEx.Client.Proto.Protobuf.Order{action: "BUY", total_quantity: "100", order_type: "LMT"}
+      }
+
+      {:reply, {:ok, subscription_ref}, new_state} =
+        Client.handle_call({:subscribe, self(), proto_msg, []}, {self(), make_ref()}, state)
+
+      # Simulate receiving an OrderStatus response with order_id=200
+      order_status = %IbEx.Client.Proto.Protobuf.OrderStatus{
+        order_id: 200,
+        status: "PreSubmitted",
+        filled: "0",
+        remaining: "100"
+      }
+
+      wire_msg = <<203::big-integer-size(32), Protobuf.encode(order_status)::binary>>
+
+      assert {:noreply, ^new_state} = Client.handle_cast({:process_message, wire_msg}, new_state)
+
+      assert_receive {:ib_ex, ^subscription_ref, %IbEx.Client.Proto.Protobuf.OrderStatus{order_id: 200}}
+    end
+  end
+
+  describe "handle_cast/2 NextValidId updates" do
+    test "updates next_valid_id when a new NextValidId message arrives at any time" do
+      table_ref = Subscriptions.initialize()
+
+      state = %{
+        subscriptions_table_ref: table_ref,
+        status: :connected,
+        trace_messages: false,
+        next_valid_id: 1
+      }
+
+      # Simulate receiving a NextValidId with order_id=500
+      next_valid_id_msg = %IbEx.Client.Proto.Protobuf.NextValidId{order_id: 500}
+      proto_payload = Protobuf.encode(next_valid_id_msg)
+      wire_msg = <<209::big-integer-size(32), proto_payload::binary>>
+
+      assert {:noreply, new_state} = Client.handle_cast({:process_message, wire_msg}, state)
+      assert new_state.next_valid_id == 500
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Use TWS-assigned `next_valid_id` for order placement instead of the generic ETS counter
- After each order placement, send `IdsRequest` to TWS to obtain the next valid order ID
- Order IDs and request IDs are independent enumerations: request IDs use the ETS counter for conversation tracking, order IDs come exclusively from TWS
- Add `next_valid_id/1` public API to query the current order ID

## Test plan
- [x] Verify `IdsRequest` is sent to TWS after placing an order
- [x] Verify `PlaceOrderRequest` uses `next_valid_id` from TWS on the wire
- [x] Verify non-order streams are unaffected (use ETS counter as before)
- [x] Verify `NextValidId` messages from TWS update client state at any time
- [x] All 599 tests pass
- [x] Clean compile with `--warnings-as-errors`

vtb: 832c0387-fba2-4910-9be4-54ca835560f3