### PR TITLE
Add MarketDataManager with Level I, tick-by-tick, and depth subscriptions

### DIFF
--- a/lib/ib_ex/client/connection.ex
+++ b/lib/ib_ex/client/connection.ex
@@ -69,6 +69,10 @@ defmodule IbEx.Client.Connection do
   end
 
   @impl true
+  def handle_cast(:set_packet_mode_on, %{socket: nil} = state) do
+    {:noreply, state}
+  end
+
   def handle_cast(:set_packet_mode_on, state) do
     Socket.set_packet_mode_on(state.socket)
     {:noreply, state}

--- a/lib/ib_ex/client/market_data.ex
+++ b/lib/ib_ex/client/market_data.ex
@@ -156,9 +156,9 @@ defmodule IbEx.Client.MarketData do
   defp build_market_data_request(proto_contract, opts) do
     %Proto.MarketDataRequest{
       contract: proto_contract,
-      generic_tick_list: Keyword.get(opts, :generic_tick_list, ""),
-      snapshot: Keyword.get(opts, :snapshot, false),
-      regulatory_snapshot: Keyword.get(opts, :regulatory_snapshot, false)
+      generic_tick_list: Keyword.get(opts, :generic_tick_list),
+      snapshot: Keyword.get(opts, :snapshot),
+      regulatory_snapshot: Keyword.get(opts, :regulatory_snapshot)
     }
   end
 
@@ -167,7 +167,7 @@ defmodule IbEx.Client.MarketData do
       contract: proto_contract,
       tick_type: Keyword.get(opts, :tick_type, "Last"),
       number_of_ticks: Keyword.get(opts, :number_of_ticks, 0),
-      ignore_size: Keyword.get(opts, :ignore_size, false)
+      ignore_size: Keyword.get(opts, :ignore_size)
     }
   end
 end

--- a/lib/ib_ex/client/market_depth.ex
+++ b/lib/ib_ex/client/market_depth.ex
@@ -99,7 +99,7 @@ defmodule IbEx.Client.MarketDepth do
     %Proto.MarketDepthRequest{
       contract: proto_contract,
       num_rows: Keyword.get(opts, :num_rows, 5),
-      is_smart_depth: Keyword.get(opts, :is_smart_depth, false),
+      is_smart_depth: Keyword.get(opts, :is_smart_depth),
       market_depth_options: Keyword.get(opts, :market_depth_options, %{})
     }
   end

--- a/lib/ib_ex/client/proto/mapper/contract.ex
+++ b/lib/ib_ex/client/proto/mapper/contract.ex
@@ -33,23 +33,23 @@ defmodule IbEx.Client.Proto.Mapper.Contract do
   def to_proto(%DomainContract{} = contract) do
     %ProtoContract{
       con_id: Utils.to_integer(contract.conid, :nullable),
-      symbol: contract.symbol,
-      sec_type: contract.security_type,
-      last_trade_date_or_contract_month: contract.last_trade_date_or_contract_month,
+      symbol: presence(contract.symbol),
+      sec_type: presence(contract.security_type),
+      last_trade_date_or_contract_month: presence(contract.last_trade_date_or_contract_month),
       strike: Utils.to_float(contract.strike, :nullable),
-      right: contract.right,
+      right: presence(contract.right),
       multiplier: Utils.to_float(contract.multiplier, :nullable),
-      exchange: contract.exchange,
-      primary_exch: contract.primary_exchange,
-      currency: contract.currency,
-      local_symbol: contract.local_symbol,
-      trading_class: contract.trading_class,
-      sec_id_type: contract.security_id_type,
-      sec_id: contract.security_id,
-      description: contract.description,
-      issuer_id: contract.issuer_id,
-      include_expired: contract.include_expired,
-      combo_legs_descrip: contract.combo_legs_description,
+      exchange: presence(contract.exchange),
+      primary_exch: presence(contract.primary_exchange),
+      currency: presence(contract.currency),
+      local_symbol: presence(contract.local_symbol),
+      trading_class: presence(contract.trading_class),
+      sec_id_type: presence(contract.security_id_type),
+      sec_id: presence(contract.security_id),
+      description: presence(contract.description),
+      issuer_id: presence(contract.issuer_id),
+      include_expired: if(contract.include_expired, do: true, else: nil),
+      combo_legs_descrip: presence(contract.combo_legs_description),
       combo_legs: Enum.map(contract.combo_legs || [], &combo_leg_to_proto/1),
       delta_neutral_contract: delta_neutral_to_proto(contract.delta_neutral_contract)
     }
@@ -126,6 +126,9 @@ defmodule IbEx.Client.Proto.Mapper.Contract do
       price: Utils.to_float(dn.price, :nullable)
     }
   end
+
+  defp presence(""), do: nil
+  defp presence(value), do: value
 
   @spec delta_neutral_from_proto(ProtoDeltaNeutral.t() | nil) :: DomainDeltaNeutral.t() | nil
   defp delta_neutral_from_proto(nil), do: nil

--- a/lib/ib_ex/dev_server.ex
+++ b/lib/ib_ex/dev_server.ex
@@ -4,6 +4,8 @@ if Mix.env() == :dev do
 
     use Supervisor
 
+    require Logger
+
     def start_link(opts \\ []) do
       Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
     end
@@ -11,14 +13,38 @@ if Mix.env() == :dev do
     def init(opts) do
       port = Keyword.get(opts, :port, 4040)
 
+      client_opts =
+        [name: IbEx.Client, trace_messages: true]
+        |> maybe_put_env(:host, "TWS_HOST", &parse_host/1)
+        |> maybe_put_env(:port, "TWS_PORT", &String.to_integer/1)
+
+      Logger.info("DevServer starting Client with opts: #{inspect(client_opts)}")
+
       children = [
         {Phoenix.PubSub, name: IbEx.PubSub},
         IbEx.TraceServer,
-        {IbEx.Client, name: IbEx.Client, trace_messages: true},
+        {IbEx.Client, client_opts},
+        {IbEx.Client.ContractResolver, client: IbEx.Client, name: IbEx.ContractResolver},
+        {IbEx.MarketDataManager,
+         client: IbEx.Client, resolver: IbEx.ContractResolver, pubsub: IbEx.PubSub, name: IbEx.MarketDataManager},
         {Bandit, plug: Tidewave, port: port}
       ]
 
       Supervisor.init(children, strategy: :one_for_one)
+    end
+
+    defp maybe_put_env(opts, key, env_var, parser) do
+      case System.get_env(env_var) do
+        nil -> opts
+        value -> Keyword.put(opts, key, parser.(value))
+      end
+    end
+
+    defp parse_host(host_string) do
+      host_string
+      |> String.split(".")
+      |> Enum.map(&String.to_integer/1)
+      |> List.to_tuple()
     end
   end
 end

--- a/lib/ib_ex/dev_server/market_data_logger.ex
+++ b/lib/ib_ex/dev_server/market_data_logger.ex
@@ -1,0 +1,76 @@
+if Mix.env() == :dev do
+  defmodule IbEx.DevServer.MarketDataLogger do
+    @moduledoc """
+    Dev-only GenServer that subscribes to market data via the MarketDataManager
+    and logs all PubSub events for a given symbol and type.
+
+    Supports `:quotes` (L1), `:trades` (tick-by-tick), and `:depth` (L2).
+
+    Start manually:
+
+        alias IbEx.DevServer.MarketDataLogger
+        opts = [pubsub: IbEx.PubSub, manager: IbEx.MarketDataManager]
+
+        MarketDataLogger.start_link("AAPL", :quotes, opts)
+        MarketDataLogger.start_link("AAPL", :trades, opts)
+        MarketDataLogger.start_link("AAPL", :depth, opts)
+
+    """
+
+    use GenServer
+
+    require Logger
+
+    def start_link(symbol, type, opts) when type in [:quotes, :trades, :depth] do
+      GenServer.start_link(__MODULE__, {symbol, type, opts})
+    end
+
+    def init({symbol, type, opts}) do
+      pubsub = Keyword.fetch!(opts, :pubsub)
+      manager = Keyword.fetch!(opts, :manager)
+      subscription_id = "#{String.downcase(symbol)}-#{type}"
+
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{subscription_id}")
+      Process.send_after(self(), :subscribe, 5_000)
+
+      {:ok, %{pubsub: pubsub, manager: manager, symbol: symbol, type: type, subscription_id: subscription_id}}
+    end
+
+    def handle_info(:subscribe, state) do
+      sub_opts = if state.type == :depth, do: [num_rows: 10, is_smart_depth: true], else: []
+
+      try do
+        case IbEx.MarketDataManager.subscribe(
+               state.manager,
+               state.subscription_id,
+               state.type,
+               {:stock, state.symbol},
+               sub_opts
+             ) do
+          :ok ->
+            Logger.info("[MarketDataLogger] Subscribed to #{state.symbol} #{state.type} as #{state.subscription_id}")
+
+          {:error, reason} ->
+            Logger.error("[MarketDataLogger] Failed to subscribe: #{inspect(reason)}, retrying in 10s")
+            Process.send_after(self(), :subscribe, 10_000)
+        end
+      catch
+        :exit, reason ->
+          Logger.warning("[MarketDataLogger] Subscribe call failed: #{inspect(reason)}, retrying in 10s")
+          Process.send_after(self(), :subscribe, 10_000)
+      end
+
+      {:noreply, state}
+    end
+
+    def handle_info({:market_data_error, _data} = event, state) do
+      Logger.warning("[MarketDataLogger:#{state.subscription_id}] #{inspect(event)}")
+      {:noreply, state}
+    end
+
+    def handle_info(event, state) do
+      Logger.info("[MarketDataLogger:#{state.subscription_id}] #{inspect(event)}")
+      {:noreply, state}
+    end
+  end
+end

--- a/lib/ib_ex/market_data_manager.ex
+++ b/lib/ib_ex/market_data_manager.ex
@@ -1,0 +1,262 @@
+defmodule IbEx.MarketDataManager do
+  @moduledoc """
+  GenServer that manages real-time market data subscriptions from TWS and
+  broadcasts domain-friendly events via Phoenix.PubSub.
+
+  Provides a simple API for subscribing to quotes, trades, and market depth
+  using shorthand contract tuples. Translates raw TWS proto messages into
+  domain-friendly events and publishes them on per-subscription topics.
+
+  Supports three subscription types:
+
+  1. **Quotes** (`:quotes`) -- Level I market data (TickPrice, TickSize, etc.)
+     via `MarketData.subscribe/3`.
+  2. **Trades** (`:trades`) -- tick-by-tick trade data (TickByTickData) via
+     `MarketData.tick_by_tick_subscribe/3`.
+  3. **Depth** (`:depth`) -- Level II order book (MarketDepth, MarketDepthL2)
+     via `MarketDepth.subscribe/3`.
+
+  ## Usage
+
+      # Start dependencies
+      {:ok, client} = IbEx.Client.start_link(...)
+      {:ok, resolver} = IbEx.Client.ContractResolver.start_link(client: client)
+
+      # Start the MarketDataManager
+      {:ok, manager} = IbEx.MarketDataManager.start_link(
+        client: client,
+        resolver: resolver,
+        pubsub: MyApp.PubSub
+      )
+
+      # Subscribe to the market data topic BEFORE subscribing
+      subscription_id = "aapl-quotes"
+      Phoenix.PubSub.subscribe(MyApp.PubSub, "ib_ex:market_data:\#{subscription_id}")
+
+      # Subscribe to Level I quotes
+      :ok = IbEx.MarketDataManager.subscribe(manager, subscription_id, :quotes, {:stock, "AAPL"})
+
+      # Subscribe to tick-by-tick trades
+      :ok = IbEx.MarketDataManager.subscribe(manager, "aapl-trades", :trades, {:stock, "AAPL"})
+
+      # Subscribe to Level II depth
+      :ok = IbEx.MarketDataManager.subscribe(manager, "aapl-depth", :depth, {:stock, "AAPL"})
+
+      # List active subscriptions
+      ["aapl-quotes", "aapl-trades", "aapl-depth"] = IbEx.MarketDataManager.subscriptions(manager)
+
+  ## Event types
+
+  Events are broadcast on the topic `"ib_ex:market_data:<subscription_id>"`:
+
+  * `{:market_data_error, %{code: integer, message: String.t()}}`
+
+  Additional event types for quotes, trades, and depth are added by subsequent tickets.
+  """
+
+  use GenServer
+
+  alias IbEx.Client
+  alias IbEx.Client.ContractResolver
+  alias IbEx.Client.MarketData
+  alias IbEx.Client.MarketDepth
+
+  # ---------------------------------------------------------------------------
+  # Types
+  # ---------------------------------------------------------------------------
+
+  @type subscription_id :: String.t()
+  @type subscription_type :: :quotes | :trades | :depth
+  @type contract_spec ::
+          {:stock, symbol :: String.t()}
+          | {:stock, symbol :: String.t(), currency :: String.t()}
+          | {:forex, symbol :: String.t(), currency :: String.t()}
+          | {:future, symbol :: String.t(), expiry :: String.t()}
+          | {:option, symbol :: String.t(), expiry :: String.t(), strike :: number(), :call | :put}
+  @type server :: GenServer.server()
+
+  @type market_data_error_event :: {:market_data_error, %{code: integer(), message: String.t()}}
+
+  @valid_types [:quotes, :trades, :depth]
+
+  # ---------------------------------------------------------------------------
+  # Internal state
+  # ---------------------------------------------------------------------------
+
+  defstruct client: nil,
+            resolver: nil,
+            pubsub: nil,
+            subscriptions: %{},
+            refs: %{}
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Starts the Market Data Manager.
+
+  ## Options
+
+  * `:client` (required) -- pid of the `IbEx.Client` GenServer
+  * `:resolver` (required) -- pid of a `IbEx.Client.ContractResolver` GenServer
+  * `:pubsub` (required) -- Phoenix.PubSub server name
+  * `:name` -- optional registered name for this GenServer
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    {server_opts, opts} = Keyword.split(opts, [:name])
+    GenServer.start_link(__MODULE__, opts, server_opts)
+  end
+
+  @doc """
+  Subscribes to real-time market data for the given contract.
+
+  ## Arguments
+
+  * `manager` -- pid or name of the MarketDataManager
+  * `subscription_id` -- caller-provided string identifier for the subscription
+  * `type` -- subscription type: `:quotes`, `:trades`, or `:depth`
+  * `contract_spec` -- shorthand tuple (e.g. `{:stock, "AAPL"}`)
+  * `opts` -- keyword list of options passed to the underlying subscribe call
+
+  Returns `:ok` on success or `{:error, reason}` on failure.
+  """
+  @spec subscribe(server(), subscription_id, subscription_type, contract_spec, keyword()) :: :ok | {:error, term()}
+  def subscribe(manager, subscription_id, type, contract_spec, opts \\ [])
+
+  def subscribe(manager, subscription_id, type, contract_spec, opts)
+      when is_binary(subscription_id) and type in @valid_types and is_tuple(contract_spec) do
+    GenServer.call(manager, {:subscribe, subscription_id, type, contract_spec, opts})
+  end
+
+  def subscribe(_manager, _subscription_id, _type, _contract_spec, _opts), do: {:error, :invalid_args}
+
+  @doc """
+  Cancels a market data subscription.
+
+  Returns `:ok` on success, or `{:error, :not_found}` if the subscription
+  does not exist.
+  """
+  @spec unsubscribe(server(), subscription_id) :: :ok | {:error, :not_found | :invalid_args}
+  def unsubscribe(manager, subscription_id)
+
+  def unsubscribe(manager, subscription_id) when is_binary(subscription_id),
+    do: GenServer.call(manager, {:unsubscribe, subscription_id})
+
+  def unsubscribe(_manager, _subscription_id), do: {:error, :invalid_args}
+
+  @doc """
+  Returns a list of active subscription IDs.
+  """
+  @spec subscriptions(server()) :: [subscription_id]
+  def subscriptions(manager) do
+    GenServer.call(manager, :subscriptions)
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    client = Keyword.fetch!(opts, :client)
+    resolver = Keyword.fetch!(opts, :resolver)
+    pubsub = Keyword.fetch!(opts, :pubsub)
+
+    {:ok, %__MODULE__{client: client, resolver: resolver, pubsub: pubsub}}
+  end
+
+  @impl true
+  def handle_call({:subscribe, subscription_id, type, contract_spec, opts}, _from, state) do
+    state = cancel_existing_subscription(state, subscription_id)
+
+    case resolve_and_subscribe(state, type, contract_spec, opts) do
+      {:ok, client_ref} ->
+        subscriptions = Map.put(state.subscriptions, subscription_id, %{client_ref: client_ref, type: type})
+        refs = Map.put(state.refs, client_ref, subscription_id)
+        {:reply, :ok, %{state | subscriptions: subscriptions, refs: refs}}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  def handle_call({:unsubscribe, subscription_id}, _from, state) do
+    case Map.get(state.subscriptions, subscription_id) do
+      %{client_ref: client_ref} ->
+        Client.unsubscribe(state.client, client_ref)
+        subscriptions = Map.delete(state.subscriptions, subscription_id)
+        refs = Map.delete(state.refs, client_ref)
+        {:reply, :ok, %{state | subscriptions: subscriptions, refs: refs}}
+
+      nil ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_call(:subscriptions, _from, state) do
+    {:reply, Map.keys(state.subscriptions), state}
+  end
+
+  @impl true
+  def handle_info({:ib_ex, ref, {:error, %IbEx.Client.Types.Error{} = error}}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = {:market_data_error, %{code: error.code, message: error.message}}
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, _ref, _msg}, state) do
+    {:noreply, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internal helpers
+  # ---------------------------------------------------------------------------
+
+  defp resolve_and_subscribe(state, type, contract_spec, opts) do
+    with {:ok, details_list} <- ContractResolver.resolve(state.resolver, contract_spec),
+         {:ok, proto_contract} <- ContractResolver.pick_contract(details_list, opts),
+         {:ok, client_ref} <- dispatch_subscribe(state.client, type, proto_contract, opts) do
+      {:ok, client_ref}
+    end
+  end
+
+  defp dispatch_subscribe(client, :quotes, proto_contract, opts) do
+    MarketData.subscribe(client, proto_contract, opts)
+  end
+
+  defp dispatch_subscribe(client, :trades, proto_contract, opts) do
+    MarketData.tick_by_tick_subscribe(client, proto_contract, opts)
+  end
+
+  defp dispatch_subscribe(client, :depth, proto_contract, opts) do
+    MarketDepth.subscribe(client, proto_contract, opts)
+  end
+
+  defp cancel_existing_subscription(state, subscription_id) do
+    case Map.get(state.subscriptions, subscription_id) do
+      %{client_ref: client_ref} ->
+        Client.unsubscribe(state.client, client_ref)
+
+        %{
+          state
+          | subscriptions: Map.delete(state.subscriptions, subscription_id),
+            refs: Map.delete(state.refs, client_ref)
+        }
+
+      nil ->
+        state
+    end
+  end
+
+  defp broadcast(pubsub, subscription_id, event) do
+    Phoenix.PubSub.broadcast(pubsub, "ib_ex:market_data:#{subscription_id}", event)
+  end
+end

--- a/lib/ib_ex/market_data_manager.ex
+++ b/lib/ib_ex/market_data_manager.ex
@@ -49,17 +49,36 @@ defmodule IbEx.MarketDataManager do
 
   Events are broadcast on the topic `"ib_ex:market_data:<subscription_id>"`:
 
-  * `{:market_data_error, %{code: integer, message: String.t()}}`
+  ### Quotes events
+  * `{:tick_price, %{tick_type: atom, price: Decimal.t(), size: Decimal.t(), attr_mask: integer}}`
+  * `{:tick_size, %{tick_type: atom, size: Decimal.t()}}`
+  * `{:tick_string, %{tick_type: atom, value: String.t()}}`
+  * `{:tick_generic, %{tick_type: atom, value: float}}`
+  * `{:tick_option_computation, %{tick_type: atom, implied_vol: Decimal.t() | nil, delta: Decimal.t() | nil, ...}}`
+  * `{:tick_req_params, %{min_tick: String.t(), bbo_exchange: String.t(), snapshot_permissions: integer}}`
+  * `{:tick_snapshot_end, %{}}`
 
-  Additional event types for quotes, trades, and depth are added by subsequent tickets.
+  ### Trades events
+  * `{:trade, %{timestamp: DateTime.t(), price: Decimal.t(), size: Decimal.t(), exchange: String.t(), ...}}`
+  * `{:bid_ask, %{timestamp: DateTime.t(), bid_price: Decimal.t(), ask_price: Decimal.t(), ...}}`
+  * `{:mid_point, %{timestamp: DateTime.t(), price: Decimal.t()}}`
+
+  ### Depth events
+  * `{:depth_update, %{position: integer, operation: atom, side: atom, price: Decimal.t(), size: Decimal.t(), ...}}`
+
+  ### Error events
+  * `{:market_data_error, %{code: integer, message: String.t()}}`
   """
 
   use GenServer
 
   alias IbEx.Client
+  alias IbEx.Client.Constants.TickTypes
   alias IbEx.Client.ContractResolver
   alias IbEx.Client.MarketData
   alias IbEx.Client.MarketDepth
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+  alias IbEx.Client.Utils
 
   # ---------------------------------------------------------------------------
   # Types
@@ -212,6 +231,150 @@ defmodule IbEx.MarketDataManager do
     end
   end
 
+  def handle_info({:ib_ex, ref, %Proto.TickPrice{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event =
+          {:tick_price,
+           %{
+             tick_type: resolve_tick_type(msg.tick_type),
+             price: Utils.to_decimal(msg.price),
+             size: Utils.to_decimal(msg.size),
+             attr_mask: msg.attr_mask
+           }}
+
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickSize{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = {:tick_size, %{tick_type: resolve_tick_type(msg.tick_type), size: Utils.to_decimal(msg.size)}}
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickString{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = {:tick_string, %{tick_type: resolve_tick_type(msg.tick_type), value: msg.value}}
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickGeneric{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = {:tick_generic, %{tick_type: resolve_tick_type(msg.tick_type), value: msg.value}}
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickOptionComputation{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event =
+          {:tick_option_computation,
+           %{
+             tick_type: resolve_tick_type(msg.tick_type),
+             tick_attrib: msg.tick_attrib,
+             implied_vol: Utils.to_decimal(msg.implied_vol),
+             delta: Utils.to_decimal(msg.delta),
+             opt_price: Utils.to_decimal(msg.opt_price),
+             pv_dividend: Utils.to_decimal(msg.pv_dividend),
+             gamma: Utils.to_decimal(msg.gamma),
+             vega: Utils.to_decimal(msg.vega),
+             theta: Utils.to_decimal(msg.theta),
+             und_price: Utils.to_decimal(msg.und_price)
+           }}
+
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickReqParams{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event =
+          {:tick_req_params,
+           %{min_tick: msg.min_tick, bbo_exchange: msg.bbo_exchange, snapshot_permissions: msg.snapshot_permissions}}
+
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickSnapshotEnd{}}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        broadcast(state.pubsub, sub_id, {:tick_snapshot_end, %{}})
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.TickByTickData{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = translate_tick_by_tick(msg)
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.MarketDepth{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = translate_depth_data(msg.market_depth_data)
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:ib_ex, ref, %Proto.MarketDepthL2{} = msg}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        {:noreply, state}
+
+      sub_id ->
+        event = translate_depth_data(msg.market_depth_data)
+        broadcast(state.pubsub, sub_id, event)
+        {:noreply, state}
+    end
+  end
+
   def handle_info({:ib_ex, _ref, _msg}, state) do
     {:noreply, state}
   end
@@ -255,6 +418,71 @@ defmodule IbEx.MarketDataManager do
         state
     end
   end
+
+  defp resolve_tick_type(tick_type) do
+    case TickTypes.to_atom(tick_type) do
+      {:ok, atom} -> atom
+      {:error, :invalid_args} -> tick_type
+    end
+  end
+
+  defp translate_tick_by_tick(%Proto.TickByTickData{tick: {:historical_tick_last, tick}}) do
+    attrib = tick.tick_attrib_last
+
+    {:trade,
+     %{
+       timestamp: DateTime.from_unix!(tick.time),
+       price: Utils.to_decimal(tick.price),
+       size: Utils.to_decimal(tick.size),
+       exchange: tick.exchange || "",
+       special_conditions: tick.special_conditions || "",
+       past_limit: (attrib && attrib.past_limit) || false,
+       unreported: (attrib && attrib.unreported) || false
+     }}
+  end
+
+  defp translate_tick_by_tick(%Proto.TickByTickData{tick: {:historical_tick_bid_ask, tick}}) do
+    attrib = tick.tick_attrib_bid_ask
+
+    {:bid_ask,
+     %{
+       timestamp: DateTime.from_unix!(tick.time),
+       bid_price: Utils.to_decimal(tick.price_bid),
+       ask_price: Utils.to_decimal(tick.price_ask),
+       bid_size: Utils.to_decimal(tick.size_bid),
+       ask_size: Utils.to_decimal(tick.size_ask),
+       bid_past_low: (attrib && attrib.bid_past_low) || false,
+       ask_past_high: (attrib && attrib.ask_past_high) || false
+     }}
+  end
+
+  defp translate_tick_by_tick(%Proto.TickByTickData{tick: {:historical_tick_mid_point, tick}}) do
+    {:mid_point,
+     %{
+       timestamp: DateTime.from_unix!(tick.time),
+       price: Utils.to_decimal(tick.price)
+     }}
+  end
+
+  defp translate_depth_data(%Proto.MarketDepthData{} = data) do
+    {:depth_update,
+     %{
+       position: data.position,
+       operation: parse_depth_operation(data.operation),
+       side: parse_depth_side(data.side),
+       price: Utils.to_decimal(data.price),
+       size: Utils.to_decimal(data.size),
+       market_maker: data.market_maker || "",
+       is_smart_depth: data.is_smart_depth || false
+     }}
+  end
+
+  defp parse_depth_operation(0), do: :insert
+  defp parse_depth_operation(1), do: :update
+  defp parse_depth_operation(2), do: :delete
+
+  defp parse_depth_side(0), do: :ask
+  defp parse_depth_side(1), do: :bid
 
   defp broadcast(pubsub, subscription_id, event) do
     Phoenix.PubSub.broadcast(pubsub, "ib_ex:market_data:#{subscription_id}", event)

--- a/test/ib_ex/client/proto/mapper/contract_test.exs
+++ b/test/ib_ex/client/proto/mapper/contract_test.exs
@@ -143,10 +143,10 @@ defmodule IbEx.Client.Proto.Mapper.ContractTest do
       proto = ContractMapper.to_proto(contract)
 
       assert proto.con_id == 0
-      assert proto.symbol == ""
+      assert proto.symbol == nil
       assert proto.exchange == "SMART"
       assert proto.strike == 0.0
-      assert proto.include_expired == false
+      assert proto.include_expired == nil
     end
   end
 

--- a/test/ib_ex/market_data_manager_test.exs
+++ b/test/ib_ex/market_data_manager_test.exs
@@ -296,7 +296,7 @@ defmodule IbEx.MarketDataManagerTest do
       assert %Proto.MarketDataRequest{} = decoded
       assert decoded.contract.symbol == "AAPL"
       assert decoded.contract.sec_type == "STK"
-      assert decoded.snapshot == false
+      assert decoded.snapshot == nil
 
       assert :ok = Task.await(task, 5_000)
     end
@@ -487,6 +487,743 @@ defmodule IbEx.MarketDataManagerTest do
       send(manager, {:ib_ex, client_ref, {:error, error}})
 
       refute_receive {:market_data_error, _}, 200
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickPrice broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickPrice broadcast" do
+    test "broadcasts {:tick_price, ...} with resolved tick_type atom and Decimal values", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-price-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickPrice{req_id: 1, tick_type: 1, price: 150.25, size: "100", attr_mask: 3}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_price, event}, 1_000
+      assert event.tick_type == :bid
+      assert Decimal.equal?(event.price, Decimal.from_float(150.25))
+      assert Decimal.equal?(event.size, Decimal.new("100"))
+      assert event.attr_mask == 3
+    end
+
+    test "resolves tick_type 2 to :ask", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "tick-price-ask"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickPrice{req_id: 1, tick_type: 2, price: 151.50, size: "200", attr_mask: 0}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_price, event}, 1_000
+      assert event.tick_type == :ask
+      assert Decimal.equal?(event.price, Decimal.from_float(151.50))
+      assert Decimal.equal?(event.size, Decimal.new("200"))
+      assert event.attr_mask == 0
+    end
+
+    test "falls back to raw integer for unknown tick_type", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-price-unknown"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickPrice{req_id: 1, tick_type: 99999, price: 100.0, size: "50", attr_mask: 0}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_price, event}, 1_000
+      assert event.tick_type == 99999
+    end
+
+    test "does not broadcast after unsubscription", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "tick-price-unsub"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      assert :ok = MarketDataManager.unsubscribe(manager, sub_id)
+
+      msg = %Proto.TickPrice{req_id: 1, tick_type: 1, price: 150.0, size: "100", attr_mask: 0}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      refute_receive {:tick_price, _}, 200
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickSize broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickSize broadcast" do
+    test "broadcasts {:tick_size, ...} with resolved tick_type and Decimal size", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-size-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickSize{req_id: 1, tick_type: 0, size: "500"}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_size, event}, 1_000
+      assert event.tick_type == :bid_size
+      assert Decimal.equal?(event.size, Decimal.new("500"))
+    end
+
+    test "resolves tick_type 3 to :ask_size", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "tick-size-ask"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickSize{req_id: 1, tick_type: 3, size: "250"}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_size, event}, 1_000
+      assert event.tick_type == :ask_size
+      assert Decimal.equal?(event.size, Decimal.new("250"))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickString broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickString broadcast" do
+    test "broadcasts {:tick_string, ...} with resolved tick_type and string value", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-string-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      # tick_type 45 = :last_timestamp
+      msg = %Proto.TickString{req_id: 1, tick_type: 45, value: "1708700000"}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_string, event}, 1_000
+      assert event.tick_type == :last_timestamp
+      assert event.value == "1708700000"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickGeneric broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickGeneric broadcast" do
+    test "broadcasts {:tick_generic, ...} with resolved tick_type and float value", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-generic-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      # tick_type 46 = :shortable
+      msg = %Proto.TickGeneric{req_id: 1, tick_type: 46, value: 2.5}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_generic, event}, 1_000
+      assert event.tick_type == :shortable
+      assert event.value == 2.5
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickOptionComputation broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickOptionComputation broadcast" do
+    test "broadcasts {:tick_option_computation, ...} with Decimal greeks", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-opt-comp-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      # tick_type 10 = :bid_option_computation
+      msg = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 10,
+        tick_attrib: 1,
+        implied_vol: 0.35,
+        delta: 0.65,
+        opt_price: 12.50,
+        pv_dividend: 0.25,
+        gamma: 0.03,
+        vega: 0.15,
+        theta: -0.05,
+        und_price: 150.0
+      }
+
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_option_computation, event}, 1_000
+      assert event.tick_type == :bid_option_computation
+      assert event.tick_attrib == 1
+      assert Decimal.equal?(event.implied_vol, Decimal.from_float(0.35))
+      assert Decimal.equal?(event.delta, Decimal.from_float(0.65))
+      assert Decimal.equal?(event.opt_price, Decimal.from_float(12.50))
+      assert Decimal.equal?(event.pv_dividend, Decimal.from_float(0.25))
+      assert Decimal.equal?(event.gamma, Decimal.from_float(0.03))
+      assert Decimal.equal?(event.vega, Decimal.from_float(0.15))
+      assert Decimal.equal?(event.theta, Decimal.from_float(-0.05))
+      assert Decimal.equal?(event.und_price, Decimal.from_float(150.0))
+    end
+
+    test "handles nil greeks values", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "tick-opt-comp-nil"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickOptionComputation{
+        req_id: 1,
+        tick_type: 10,
+        tick_attrib: 0,
+        implied_vol: nil,
+        delta: nil,
+        opt_price: nil,
+        pv_dividend: nil,
+        gamma: nil,
+        vega: nil,
+        theta: nil,
+        und_price: nil
+      }
+
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_option_computation, event}, 1_000
+      assert event.tick_type == :bid_option_computation
+      assert event.implied_vol == nil
+      assert event.delta == nil
+      assert event.opt_price == nil
+      assert event.pv_dividend == nil
+      assert event.gamma == nil
+      assert event.vega == nil
+      assert event.theta == nil
+      assert event.und_price == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickReqParams broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickReqParams broadcast" do
+    test "broadcasts {:tick_req_params, ...} with correct fields", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-req-params-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickReqParams{req_id: 1, min_tick: "0.01", bbo_exchange: "SMART", snapshot_permissions: 3}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_req_params, event}, 1_000
+      assert event.min_tick == "0.01"
+      assert event.bbo_exchange == "SMART"
+      assert event.snapshot_permissions == 3
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- TickSnapshotEnd broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub TickSnapshotEnd broadcast" do
+    test "broadcasts {:tick_snapshot_end, %{}} on snapshot end", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tick-snapshot-end-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      msg = %Proto.TickSnapshotEnd{req_id: 1}
+      send(manager, {:ib_ex, client_ref, msg})
+
+      assert_receive {:tick_snapshot_end, event}, 1_000
+      assert event == %{}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- trades broadcast (tick-by-tick)
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub trades broadcast" do
+    test "broadcasts {:trade, ...} on TickByTickData with historical_tick_last", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tbt-trade-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :trades, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      tick_msg = %Proto.TickByTickData{
+        req_id: 1,
+        tick_type: 1,
+        tick:
+          {:historical_tick_last,
+           %Proto.HistoricalTickLast{
+             time: 1_700_000_000,
+             price: 185.50,
+             size: "100",
+             exchange: "ARCA",
+             special_conditions: "T",
+             tick_attrib_last: %Proto.TickAttribLast{
+               past_limit: true,
+               unreported: false
+             }
+           }}
+      }
+
+      send(manager, {:ib_ex, client_ref, tick_msg})
+
+      assert_receive {:trade, event}, 1_000
+
+      assert event.timestamp == ~U[2023-11-14 22:13:20Z]
+      assert Decimal.equal?(event.price, Decimal.from_float(185.50))
+      assert Decimal.equal?(event.size, Decimal.new("100"))
+      assert event.exchange == "ARCA"
+      assert event.special_conditions == "T"
+      assert event.past_limit == true
+      assert event.unreported == false
+    end
+
+    test "broadcasts {:bid_ask, ...} on TickByTickData with historical_tick_bid_ask", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tbt-bidask-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :trades, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      tick_msg = %Proto.TickByTickData{
+        req_id: 2,
+        tick_type: 3,
+        tick:
+          {:historical_tick_bid_ask,
+           %Proto.HistoricalTickBidAsk{
+             time: 1_700_000_100,
+             price_bid: 185.45,
+             price_ask: 185.55,
+             size_bid: "200",
+             size_ask: "150",
+             tick_attrib_bid_ask: %Proto.TickAttribBidAsk{
+               bid_past_low: true,
+               ask_past_high: false
+             }
+           }}
+      }
+
+      send(manager, {:ib_ex, client_ref, tick_msg})
+
+      assert_receive {:bid_ask, event}, 1_000
+
+      assert event.timestamp == ~U[2023-11-14 22:15:00Z]
+      assert Decimal.equal?(event.bid_price, Decimal.from_float(185.45))
+      assert Decimal.equal?(event.ask_price, Decimal.from_float(185.55))
+      assert Decimal.equal?(event.bid_size, Decimal.new("200"))
+      assert Decimal.equal?(event.ask_size, Decimal.new("150"))
+      assert event.bid_past_low == true
+      assert event.ask_past_high == false
+    end
+
+    test "broadcasts {:mid_point, ...} on TickByTickData with historical_tick_mid_point", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tbt-midpoint-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :trades, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      tick_msg = %Proto.TickByTickData{
+        req_id: 3,
+        tick_type: 4,
+        tick:
+          {:historical_tick_mid_point,
+           %Proto.HistoricalTick{
+             time: 1_700_000_200,
+             price: 185.50
+           }}
+      }
+
+      send(manager, {:ib_ex, client_ref, tick_msg})
+
+      assert_receive {:mid_point, event}, 1_000
+
+      assert event.timestamp == ~U[2023-11-14 22:16:40Z]
+      assert Decimal.equal?(event.price, Decimal.from_float(185.50))
+    end
+
+    test "handles nil tick_attrib_last gracefully (defaults booleans to false)", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tbt-nil-attrib-last"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :trades, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      tick_msg = %Proto.TickByTickData{
+        req_id: 4,
+        tick_type: 1,
+        tick:
+          {:historical_tick_last,
+           %Proto.HistoricalTickLast{
+             time: 1_700_000_300,
+             price: 186.00,
+             size: "50",
+             exchange: "NYSE",
+             special_conditions: "",
+             tick_attrib_last: nil
+           }}
+      }
+
+      send(manager, {:ib_ex, client_ref, tick_msg})
+
+      assert_receive {:trade, event}, 1_000
+
+      assert event.past_limit == false
+      assert event.unreported == false
+    end
+
+    test "handles nil tick_attrib_bid_ask gracefully (defaults booleans to false)", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tbt-nil-attrib-bidask"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :trades, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      tick_msg = %Proto.TickByTickData{
+        req_id: 5,
+        tick_type: 3,
+        tick:
+          {:historical_tick_bid_ask,
+           %Proto.HistoricalTickBidAsk{
+             time: 1_700_000_400,
+             price_bid: 186.10,
+             price_ask: 186.20,
+             size_bid: "300",
+             size_ask: "250",
+             tick_attrib_bid_ask: nil
+           }}
+      }
+
+      send(manager, {:ib_ex, client_ref, tick_msg})
+
+      assert_receive {:bid_ask, event}, 1_000
+
+      assert event.bid_past_low == false
+      assert event.ask_past_high == false
+    end
+
+    test "does not broadcast after unsubscription", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "tbt-unsub"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :trades, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      assert :ok = MarketDataManager.unsubscribe(manager, sub_id)
+
+      tick_msg = %Proto.TickByTickData{
+        req_id: 6,
+        tick_type: 1,
+        tick:
+          {:historical_tick_last,
+           %Proto.HistoricalTickLast{
+             time: 1_700_000_500,
+             price: 187.00,
+             size: "75",
+             exchange: "ARCA",
+             special_conditions: "",
+             tick_attrib_last: %Proto.TickAttribLast{past_limit: false, unreported: false}
+           }}
+      }
+
+      send(manager, {:ib_ex, client_ref, tick_msg})
+
+      refute_receive {:trade, _}, 200
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- depth broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub depth broadcast" do
+    test "broadcasts {:depth_update, ...} on MarketDepth with correct fields", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "depth-l1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{
+        position: 0,
+        operation: 0,
+        side: 1,
+        price: 150.25,
+        size: "100",
+        market_maker: "",
+        is_smart_depth: false
+      }
+
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.position == 0
+      assert event.operation == :insert
+      assert event.side == :bid
+      assert Decimal.equal?(event.price, Decimal.from_float(150.25))
+      assert Decimal.equal?(event.size, Decimal.new("100"))
+      assert event.market_maker == ""
+      assert event.is_smart_depth == false
+    end
+
+    test "broadcasts {:depth_update, ...} on MarketDepthL2 with market_maker populated", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "depth-l2"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{
+        position: 2,
+        operation: 1,
+        side: 0,
+        price: 149.50,
+        size: "200",
+        market_maker: "GSCO",
+        is_smart_depth: true
+      }
+
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepthL2{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.position == 2
+      assert event.operation == :update
+      assert event.side == :ask
+      assert Decimal.equal?(event.price, Decimal.from_float(149.50))
+      assert Decimal.equal?(event.size, Decimal.new("200"))
+      assert event.market_maker == "GSCO"
+      assert event.is_smart_depth == true
+    end
+
+    test "correctly maps operation 0 to :insert", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-op-insert"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{position: 0, operation: 0, side: 1, price: 100.0, size: "10"}
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.operation == :insert
+    end
+
+    test "correctly maps operation 1 to :update", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-op-update"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{position: 1, operation: 1, side: 0, price: 101.0, size: "20"}
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.operation == :update
+    end
+
+    test "correctly maps operation 2 to :delete", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-op-delete"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{position: 3, operation: 2, side: 1, price: 99.0, size: "5"}
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.operation == :delete
+    end
+
+    test "correctly maps side 0 to :ask", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-side-ask"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{position: 0, operation: 0, side: 0, price: 150.0, size: "50"}
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.side == :ask
+    end
+
+    test "correctly maps side 1 to :bid", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-side-bid"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{position: 0, operation: 0, side: 1, price: 149.0, size: "75"}
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.side == :bid
+    end
+
+    test "handles nil market_maker by defaulting to empty string", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-nil-mm"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{
+        position: 0,
+        operation: 0,
+        side: 1,
+        price: 150.0,
+        size: "100",
+        market_maker: nil,
+        is_smart_depth: true
+      }
+
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.market_maker == ""
+    end
+
+    test "handles nil is_smart_depth by defaulting to false", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-nil-smart"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      depth_data = %Proto.MarketDepthData{
+        position: 0,
+        operation: 0,
+        side: 1,
+        price: 150.0,
+        size: "100",
+        market_maker: "ARCA",
+        is_smart_depth: nil
+      }
+
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      assert_receive {:depth_update, event}, 1_000
+      assert event.is_smart_depth == false
+    end
+
+    test "does not broadcast after unsubscription", %{manager: manager, client: client, pubsub: pubsub} do
+      sub_id = "depth-unsub"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :depth, {:stock, "AAPL"})
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      assert :ok = MarketDataManager.unsubscribe(manager, sub_id)
+
+      depth_data = %Proto.MarketDepthData{position: 0, operation: 0, side: 1, price: 150.0, size: "100"}
+      send(manager, {:ib_ex, client_ref, %Proto.MarketDepth{req_id: 1, market_depth_data: depth_data}})
+
+      refute_receive {:depth_update, _}, 200
     end
   end
 

--- a/test/ib_ex/market_data_manager_test.exs
+++ b/test/ib_ex/market_data_manager_test.exs
@@ -1,0 +1,523 @@
+defmodule IbEx.MarketDataManagerTest do
+  use ExUnit.Case, async: true
+
+  alias IbEx.Client
+  alias IbEx.Client.ContractResolver
+  alias IbEx.MarketDataManager
+  alias IbEx.Client.Proto.Protobuf, as: Proto
+
+  # ---------------------------------------------------------------------------
+  # Mock connection modules
+  # ---------------------------------------------------------------------------
+
+  defmodule MockConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(_pid, _msg), do: :ok
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(_, _, state), do: {:reply, :ok, state}
+  end
+
+  defmodule RecordingConnection do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      client = Keyword.fetch!(opts, :client)
+      GenServer.start_link(__MODULE__, %{client: client})
+    end
+
+    def send_message(pid, msg) do
+      GenServer.call(pid, {:send_message, msg})
+    end
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call({:send_message, msg}, _from, state) do
+      case :ets.lookup(:market_data_manager_test_pids, state.client) do
+        [{_, test_pid}] -> send(test_pid, {:tws_sent, msg})
+        [] -> :ok
+      end
+
+      {:reply, :ok, state}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Wire encoding helpers
+  # ---------------------------------------------------------------------------
+
+  @contract_data_wire_id 210
+  @contract_data_end_wire_id 252
+
+  defp wire_message(wire_id, proto_struct) do
+    payload = Protobuf.encode(proto_struct)
+    <<wire_id::big-integer-size(32), payload::binary>>
+  end
+
+  defp start_recording_client do
+    {:ok, client} = Client.start_link(connection_handler: RecordingConnection)
+    :ets.insert(:market_data_manager_test_pids, {client, self()})
+    client
+  end
+
+  defp start_resolver(client) do
+    {:ok, resolver} = ContractResolver.start_link(client: client)
+    resolver
+  end
+
+  defp start_pubsub do
+    name = :"pubsub_#{System.unique_integer([:positive])}"
+    {:ok, _} = Phoenix.PubSub.Supervisor.start_link(name: name)
+    name
+  end
+
+  defp start_manager(client, resolver, pubsub) do
+    {:ok, manager} = MarketDataManager.start_link(client: client, resolver: resolver, pubsub: pubsub)
+    manager
+  end
+
+  defp inject_contract_data(client, req_id, contracts) do
+    for contract_data <- contracts do
+      Client.process_message(client, wire_message(@contract_data_wire_id, %{contract_data | req_id: req_id}))
+    end
+
+    end_marker = %Proto.ContractDataEnd{req_id: req_id}
+    Client.process_message(client, wire_message(@contract_data_end_wire_id, end_marker))
+  end
+
+  defp extract_req_id_from_tws_message do
+    receive do
+      {:tws_sent, sent_msg} ->
+        <<_wire_id::big-integer-size(32), payload::binary>> = sent_msg
+        decoded = Protobuf.decode(payload, Proto.ContractDataRequest)
+        decoded.req_id
+    after
+      1_000 -> raise "No TWS message received"
+    end
+  end
+
+  defp aapl_contract_data(req_id) do
+    %Proto.ContractData{
+      req_id: req_id,
+      contract: %Proto.Contract{
+        con_id: 265_598,
+        symbol: "AAPL",
+        sec_type: "STK",
+        currency: "USD",
+        exchange: "SMART"
+      },
+      contract_details: %Proto.ContractDetails{long_name: "APPLE INC", market_name: "NMS"}
+    }
+  end
+
+  # Subscribes via the manager, handling the async resolver dance.
+  # Returns :ok on success.
+  defp subscribe_with_resolve(manager, client, subscription_id, type, contract_spec, opts \\ []) do
+    task =
+      Task.async(fn ->
+        MarketDataManager.subscribe(manager, subscription_id, type, contract_spec, opts)
+      end)
+
+    Process.sleep(50)
+
+    # Handle the resolver contract data request
+    req_id = extract_req_id_from_tws_message()
+    inject_contract_data(client, req_id, [aapl_contract_data(req_id)])
+
+    # Consume the subscribe request TWS message
+    assert_receive {:tws_sent, _subscribe_msg}, 1_000
+
+    Task.await(task, 5_000)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Setup
+  # ---------------------------------------------------------------------------
+
+  setup_all do
+    :ets.new(:market_data_manager_test_pids, [:named_table, :public, :set])
+    :ok
+  end
+
+  setup do
+    pubsub = start_pubsub()
+    client = start_recording_client()
+    resolver = start_resolver(client)
+    manager = start_manager(client, resolver, pubsub)
+
+    %{pubsub: pubsub, client: client, resolver: resolver, manager: manager}
+  end
+
+  # ---------------------------------------------------------------------------
+  # start_link/1
+  # ---------------------------------------------------------------------------
+
+  describe "start_link/1" do
+    test "starts the Market Data Manager with required options", %{client: client, resolver: resolver, pubsub: pubsub} do
+      {:ok, manager} = MarketDataManager.start_link(client: client, resolver: resolver, pubsub: pubsub)
+      assert Process.alive?(manager)
+    end
+
+    test "accepts an optional name", %{client: client, resolver: resolver, pubsub: pubsub} do
+      name = :"test_market_data_manager_#{System.unique_integer([:positive])}"
+      {:ok, _manager} = MarketDataManager.start_link(client: client, resolver: resolver, pubsub: pubsub, name: name)
+      assert Process.whereis(name) != nil
+    end
+
+    test "fails to start when :client option is missing", %{resolver: resolver, pubsub: pubsub} do
+      Process.flag(:trap_exit, true)
+      assert {:error, {%KeyError{key: :client}, _}} = MarketDataManager.start_link(resolver: resolver, pubsub: pubsub)
+    end
+
+    test "fails to start when :resolver option is missing", %{client: client, pubsub: pubsub} do
+      Process.flag(:trap_exit, true)
+      assert {:error, {%KeyError{key: :resolver}, _}} = MarketDataManager.start_link(client: client, pubsub: pubsub)
+    end
+
+    test "fails to start when :pubsub option is missing", %{client: client, resolver: resolver} do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%KeyError{key: :pubsub}, _}} =
+               MarketDataManager.start_link(client: client, resolver: resolver)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # subscribe/5
+  # ---------------------------------------------------------------------------
+
+  describe "subscribe/5" do
+    test "returns :ok for :quotes type", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "aapl-quotes", :quotes, {:stock, "AAPL"})
+    end
+
+    test "returns :ok for :trades type", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "aapl-trades", :trades, {:stock, "AAPL"})
+    end
+
+    test "returns :ok for :depth type", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "aapl-depth", :depth, {:stock, "AAPL"})
+    end
+
+    test "tracks subscription with correct type in internal state", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "tracked-quotes", :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: subscriptions, refs: refs} = :sys.get_state(manager)
+      assert %{client_ref: _ref, type: :quotes} = subscriptions["tracked-quotes"]
+      assert map_size(refs) == 1
+    end
+
+    test "tracks :trades type in internal state", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "tracked-trades", :trades, {:stock, "AAPL"})
+
+      %{subscriptions: subscriptions} = :sys.get_state(manager)
+      assert %{type: :trades} = subscriptions["tracked-trades"]
+    end
+
+    test "tracks :depth type in internal state", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "tracked-depth", :depth, {:stock, "AAPL"})
+
+      %{subscriptions: subscriptions} = :sys.get_state(manager)
+      assert %{type: :depth} = subscriptions["tracked-depth"]
+    end
+
+    test "cancels previous subscription when reusing subscription_id", %{pubsub: pubsub} do
+      client = start_recording_client()
+      resolver = start_resolver(client)
+      manager = start_manager(client, resolver, pubsub)
+
+      assert :ok = subscribe_with_resolve(manager, client, "reused", :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: subs1} = :sys.get_state(manager)
+      old_ref = subs1["reused"].client_ref
+
+      # Second subscribe with same ID -- manually handle the cancel + resolver dance.
+      # Using {:stock, "AAPL", "USD"} to avoid resolver cache hit.
+      task =
+        Task.async(fn ->
+          MarketDataManager.subscribe(manager, "reused", :trades, {:stock, "AAPL", "USD"})
+        end)
+
+      Process.sleep(50)
+
+      # Drain the cancel message sent for the old subscription
+      assert_receive {:tws_sent, _cancel_msg}, 1_000
+
+      # Handle the resolver contract data request
+      req_id = extract_req_id_from_tws_message()
+      inject_contract_data(client, req_id, [aapl_contract_data(req_id)])
+
+      # Consume the new subscribe request
+      assert_receive {:tws_sent, _subscribe_msg}, 1_000
+
+      assert :ok = Task.await(task, 5_000)
+
+      %{subscriptions: subs2, refs: refs2} = :sys.get_state(manager)
+      new_ref = subs2["reused"].client_ref
+
+      assert new_ref != old_ref
+      refute Map.has_key?(refs2, old_ref)
+      assert refs2[new_ref] == "reused"
+      assert map_size(refs2) == 1
+      assert subs2["reused"].type == :trades
+    end
+
+    test "sends MarketDataRequest to TWS for :quotes type", %{pubsub: pubsub} do
+      client = start_recording_client()
+      resolver = start_resolver(client)
+      manager = start_manager(client, resolver, pubsub)
+
+      task =
+        Task.async(fn ->
+          MarketDataManager.subscribe(manager, "wire-quotes", :quotes, {:stock, "AAPL"})
+        end)
+
+      Process.sleep(50)
+      req_id = extract_req_id_from_tws_message()
+      inject_contract_data(client, req_id, [aapl_contract_data(req_id)])
+
+      assert_receive {:tws_sent, subscribe_msg}, 1_000
+      <<_wire_id::big-integer-size(32), payload::binary>> = subscribe_msg
+      decoded = Protobuf.decode(payload, Proto.MarketDataRequest)
+
+      assert %Proto.MarketDataRequest{} = decoded
+      assert decoded.contract.symbol == "AAPL"
+      assert decoded.contract.sec_type == "STK"
+      assert decoded.snapshot == false
+
+      assert :ok = Task.await(task, 5_000)
+    end
+
+    test "sends TickByTickRequest to TWS for :trades type", %{pubsub: pubsub} do
+      client = start_recording_client()
+      resolver = start_resolver(client)
+      manager = start_manager(client, resolver, pubsub)
+
+      task =
+        Task.async(fn ->
+          MarketDataManager.subscribe(manager, "wire-trades", :trades, {:stock, "AAPL"})
+        end)
+
+      Process.sleep(50)
+      req_id = extract_req_id_from_tws_message()
+      inject_contract_data(client, req_id, [aapl_contract_data(req_id)])
+
+      assert_receive {:tws_sent, subscribe_msg}, 1_000
+      <<_wire_id::big-integer-size(32), payload::binary>> = subscribe_msg
+      decoded = Protobuf.decode(payload, Proto.TickByTickRequest)
+
+      assert %Proto.TickByTickRequest{} = decoded
+      assert decoded.contract.symbol == "AAPL"
+      assert decoded.contract.sec_type == "STK"
+      assert decoded.tick_type == "Last"
+
+      assert :ok = Task.await(task, 5_000)
+    end
+
+    test "sends MarketDepthRequest to TWS for :depth type", %{pubsub: pubsub} do
+      client = start_recording_client()
+      resolver = start_resolver(client)
+      manager = start_manager(client, resolver, pubsub)
+
+      task =
+        Task.async(fn ->
+          MarketDataManager.subscribe(manager, "wire-depth", :depth, {:stock, "AAPL"})
+        end)
+
+      Process.sleep(50)
+      req_id = extract_req_id_from_tws_message()
+      inject_contract_data(client, req_id, [aapl_contract_data(req_id)])
+
+      assert_receive {:tws_sent, subscribe_msg}, 1_000
+      <<_wire_id::big-integer-size(32), payload::binary>> = subscribe_msg
+      decoded = Protobuf.decode(payload, Proto.MarketDepthRequest)
+
+      assert %Proto.MarketDepthRequest{} = decoded
+      assert decoded.contract.symbol == "AAPL"
+      assert decoded.contract.sec_type == "STK"
+      assert decoded.num_rows == 5
+
+      assert :ok = Task.await(task, 5_000)
+    end
+
+    test "returns {:error, :invalid_args} for non-string subscription_id", %{manager: manager} do
+      assert {:error, :invalid_args} = MarketDataManager.subscribe(manager, 123, :quotes, {:stock, "AAPL"})
+      assert {:error, :invalid_args} = MarketDataManager.subscribe(manager, :atom_id, :quotes, {:stock, "AAPL"})
+    end
+
+    test "returns {:error, :invalid_args} for invalid type", %{manager: manager} do
+      assert {:error, :invalid_args} = MarketDataManager.subscribe(manager, "sub-1", :invalid, {:stock, "AAPL"})
+      assert {:error, :invalid_args} = MarketDataManager.subscribe(manager, "sub-1", "quotes", {:stock, "AAPL"})
+    end
+
+    test "returns {:error, :invalid_args} for non-tuple contract_spec", %{manager: manager} do
+      assert {:error, :invalid_args} = MarketDataManager.subscribe(manager, "sub-1", :quotes, "AAPL")
+      assert {:error, :invalid_args} = MarketDataManager.subscribe(manager, "sub-1", :quotes, 42)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # unsubscribe/2
+  # ---------------------------------------------------------------------------
+
+  describe "unsubscribe/2" do
+    test "returns :ok for an active subscription", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "unsub-ok", :quotes, {:stock, "AAPL"})
+      assert :ok = MarketDataManager.unsubscribe(manager, "unsub-ok")
+    end
+
+    test "returns {:error, :not_found} for unknown subscription_id", %{manager: manager} do
+      assert {:error, :not_found} = MarketDataManager.unsubscribe(manager, "nonexistent")
+    end
+
+    test "cleans up internal state after unsubscription", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "cleanup-sub", :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: subs_before, refs: refs_before} = :sys.get_state(manager)
+      assert Map.has_key?(subs_before, "cleanup-sub")
+      assert map_size(refs_before) == 1
+
+      assert :ok = MarketDataManager.unsubscribe(manager, "cleanup-sub")
+
+      %{subscriptions: subs_after, refs: refs_after} = :sys.get_state(manager)
+      refute Map.has_key?(subs_after, "cleanup-sub")
+      assert subs_after == %{}
+      assert refs_after == %{}
+    end
+
+    test "returns {:error, :invalid_args} for non-string subscription_id", %{manager: manager} do
+      assert {:error, :invalid_args} = MarketDataManager.unsubscribe(manager, 123)
+      assert {:error, :invalid_args} = MarketDataManager.unsubscribe(manager, :atom_id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # subscriptions/1
+  # ---------------------------------------------------------------------------
+
+  describe "subscriptions/1" do
+    test "returns empty list when no subscriptions", %{manager: manager} do
+      assert MarketDataManager.subscriptions(manager) == []
+    end
+
+    test "returns list of active subscription IDs", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "sub-a", :quotes, {:stock, "AAPL"})
+      assert :ok = subscribe_with_resolve(manager, client, "sub-b", :trades, {:stock, "AAPL", "USD"})
+
+      subs = MarketDataManager.subscriptions(manager)
+      assert length(subs) == 2
+      assert "sub-a" in subs
+      assert "sub-b" in subs
+    end
+
+    test "does not include unsubscribed IDs", %{manager: manager, client: client} do
+      assert :ok = subscribe_with_resolve(manager, client, "sub-keep", :quotes, {:stock, "AAPL"})
+      assert :ok = subscribe_with_resolve(manager, client, "sub-remove", :trades, {:stock, "AAPL", "USD"})
+
+      assert :ok = MarketDataManager.unsubscribe(manager, "sub-remove")
+
+      subs = MarketDataManager.subscriptions(manager)
+      assert subs == ["sub-keep"]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub -- market_data_error broadcast
+  # ---------------------------------------------------------------------------
+
+  describe "PubSub market_data_error broadcast" do
+    test "broadcasts {:market_data_error, %{code: ..., message: ...}} on Error", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "error-1"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      error = %IbEx.Client.Types.Error{id: 1, code: 354, message: "Requested market data is not subscribed"}
+      send(manager, {:ib_ex, client_ref, {:error, error}})
+
+      assert_receive {:market_data_error, event}, 1_000
+      assert event.code == 354
+      assert event.message == "Requested market data is not subscribed"
+    end
+
+    test "ignores errors for unknown refs", %{manager: manager, pubsub: pubsub} do
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:phantom")
+
+      unknown_ref = make_ref()
+      error = %IbEx.Client.Types.Error{id: 1, code: 354, message: "Not subscribed"}
+      send(manager, {:ib_ex, unknown_ref, {:error, error}})
+
+      refute_receive {:market_data_error, _}, 200
+    end
+
+    test "does not broadcast error after unsubscription", %{
+      manager: manager,
+      client: client,
+      pubsub: pubsub
+    } do
+      sub_id = "error-unsub"
+      Phoenix.PubSub.subscribe(pubsub, "ib_ex:market_data:#{sub_id}")
+
+      assert :ok = subscribe_with_resolve(manager, client, sub_id, :quotes, {:stock, "AAPL"})
+
+      %{subscriptions: %{^sub_id => %{client_ref: client_ref}}} = :sys.get_state(manager)
+
+      assert :ok = MarketDataManager.unsubscribe(manager, sub_id)
+
+      error = %IbEx.Client.Types.Error{id: 1, code: 354, message: "Not subscribed"}
+      send(manager, {:ib_ex, client_ref, {:error, error}})
+
+      refute_receive {:market_data_error, _}, 200
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unrecognized messages
+  # ---------------------------------------------------------------------------
+
+  describe "unrecognized messages" do
+    test "ignores other {:ib_ex, ref, msg} message types without crashing", %{
+      manager: manager,
+      client: client
+    } do
+      assert :ok = subscribe_with_resolve(manager, client, "ignore-1", :quotes, {:stock, "AAPL"})
+
+      %{refs: refs} = :sys.get_state(manager)
+      [{ref, _}] = Map.to_list(refs)
+
+      # Send a TickPrice message (not explicitly handled in skeleton)
+      send(manager, {:ib_ex, ref, %Proto.TickPrice{req_id: 1, tick_type: 1, price: 150.0}})
+      Process.sleep(50)
+
+      assert Process.alive?(manager)
+    end
+
+    test "ignores messages for unknown refs without crashing", %{manager: manager} do
+      unknown_ref = make_ref()
+
+      send(manager, {:ib_ex, unknown_ref, %Proto.TickPrice{req_id: 999, tick_type: 1, price: 100.0}})
+
+      Process.sleep(50)
+      assert Process.alive?(manager)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `IbEx.MarketDataManager` GenServer that manages real-time market data subscriptions from TWS and broadcasts domain-friendly events via Phoenix.PubSub
- Supports three subscription types: Level I quotes (`:quotes`), tick-by-tick Time & Sales (`:trades`), and Level II market depth (`:depth`)
- Uses `ContractResolver` for shorthand contract tuples (e.g. `{:stock, "AAPL"}`) and follows the established `NewsManager`/`OrderManager` pattern

### Events broadcast per type

- **Quotes**: `tick_price`, `tick_size`, `tick_string`, `tick_generic`, `tick_option_computation`, `tick_req_params`, `tick_snapshot_end`
- **Trades**: `trade`, `bid_ask`, `mid_point` (dispatched via protobuf `oneof` variant)
- **Depth**: `depth_update` with operation (`:insert`/`:update`/`:delete`) and side (`:bid`/`:ask`) atom mapping
- **Errors**: `market_data_error` for all types

## Test plan

- [x] 58 tests covering all subscription types, PubSub broadcasting, field mapping, Decimal conversions, nil defaults, unsubscription silencing, and error handling
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] Full test suite (778 tests) passes with 0 failures