### PR TITLE
Add auto_reconnect option to Client

### DIFF
--- a/lib/ib_ex/client.ex
+++ b/lib/ib_ex/client.ex
@@ -34,7 +34,8 @@ defmodule IbEx.Client do
             managed_accounts: nil,
             next_valid_id: nil,
             subscriptions_table_ref: nil,
-            trace_messages: false
+            trace_messages: false,
+            auto_reconnect: true
 
   alias IbEx.Client.Connection
   alias IbEx.Client.Constants
@@ -109,7 +110,7 @@ defmodule IbEx.Client do
   def init(opts) do
     connection_opts =
       opts
-      |> Keyword.take([:host, :port])
+      |> Keyword.take([:host, :port, :auto_reconnect])
       |> Keyword.put(:client, self())
 
     connection_handler = Keyword.get(opts, :connection_handler, Connection)
@@ -118,8 +119,15 @@ defmodule IbEx.Client do
       {:ok, pid} ->
         table_ref = Subscriptions.initialize()
         trace_messages = Keyword.get(opts, :trace_messages, false)
+        auto_reconnect = Keyword.get(opts, :auto_reconnect, true)
 
-        {:ok, %__MODULE__{connection: pid, subscriptions_table_ref: table_ref, trace_messages: trace_messages}}
+        {:ok,
+         %__MODULE__{
+           connection: pid,
+           subscriptions_table_ref: table_ref,
+           trace_messages: trace_messages,
+           auto_reconnect: auto_reconnect
+         }}
 
       err ->
         {:stop, {:connection_error, err}}
@@ -171,6 +179,11 @@ defmodule IbEx.Client do
   # Triggered by the Connection process once the connection is open
   def handle_cast(:connection_opened, state) do
     {:noreply, state, {:continue, :init_connection}}
+  end
+
+  def handle_cast(:connection_closed, %{auto_reconnect: false} = state) do
+    Logger.warning("Connection lost, stopping (auto_reconnect: false)")
+    {:stop, :connection_lost, %{state | status: :disconnected, server_version: nil, connection_timestamp: nil}}
   end
 
   def handle_cast(:connection_closed, state) do

--- a/lib/ib_ex/client/connection.ex
+++ b/lib/ib_ex/client/connection.ex
@@ -10,7 +10,8 @@ defmodule IbEx.Client.Connection do
             port: nil,
             socket: nil,
             client: nil,
-            reconnect_timer_ref: nil
+            reconnect_timer_ref: nil,
+            auto_reconnect: true
 
   alias IbEx.Client
   alias __MODULE__.Socket
@@ -28,10 +29,11 @@ defmodule IbEx.Client.Connection do
   def start_link(opts) when is_list(opts) do
     host = Keyword.get(opts, :host, @default_host)
     port = Keyword.get(opts, :port, @default_port)
+    auto_reconnect = Keyword.get(opts, :auto_reconnect, true)
 
     case Keyword.fetch(opts, :client) do
       {:ok, client} ->
-        GenServer.start_link(__MODULE__, host: host, port: port, client: client)
+        GenServer.start_link(__MODULE__, host: host, port: port, client: client, auto_reconnect: auto_reconnect)
 
       :error ->
         {:error, :invalid_args}
@@ -43,12 +45,17 @@ defmodule IbEx.Client.Connection do
   end
 
   @impl true
-  def init(host: host, port: port, client: client) do
+  def init(opts) do
+    host = Keyword.fetch!(opts, :host)
+    port = Keyword.fetch!(opts, :port)
+    client = Keyword.fetch!(opts, :client)
+    auto_reconnect = Keyword.get(opts, :auto_reconnect, true)
+
     case Socket.connect(host: host, port: port) do
       {:ok, socket} ->
         Logger.info("Socket connection established")
 
-        state = %__MODULE__{host: host, port: port, socket: socket, client: client}
+        state = %__MODULE__{host: host, port: port, socket: socket, client: client, auto_reconnect: auto_reconnect}
         {:ok, state, {:continue, :signal_connection_open}}
 
       {:error, reason} ->
@@ -91,7 +98,12 @@ defmodule IbEx.Client.Connection do
 
       {:error, reason} ->
         Logger.error("Error sending message: #{inspect(reason)}")
-        {:reply, {:error, reason}, schedule_reconnect(%{state | socket: nil})}
+
+        if state.auto_reconnect do
+          {:reply, {:error, reason}, schedule_reconnect(%{state | socket: nil})}
+        else
+          {:stop, {:send_error, reason}, {:error, reason}, %{state | socket: nil}}
+        end
     end
   end
 
@@ -103,16 +115,28 @@ defmodule IbEx.Client.Connection do
 
   @impl true
   def handle_info({:tcp_closed, _}, state) do
-    Logger.warning("TCP connection closed, scheduling reconnect in #{@reconnect_interval_ms}ms")
     Client.connection_closed(state.client)
-    {:noreply, schedule_reconnect(%{state | socket: nil})}
+
+    if state.auto_reconnect do
+      Logger.warning("TCP connection closed, scheduling reconnect in #{@reconnect_interval_ms}ms")
+      {:noreply, schedule_reconnect(%{state | socket: nil})}
+    else
+      Logger.warning("TCP connection closed, stopping (auto_reconnect: false)")
+      {:stop, :tcp_closed, %{state | socket: nil}}
+    end
   end
 
   @impl true
   def handle_info({:tcp_error, _, reason}, state) do
-    Logger.warning("TCP error: #{inspect(reason)}, scheduling reconnect in #{@reconnect_interval_ms}ms")
     Client.connection_closed(state.client)
-    {:noreply, schedule_reconnect(%{state | socket: nil})}
+
+    if state.auto_reconnect do
+      Logger.warning("TCP error: #{inspect(reason)}, scheduling reconnect in #{@reconnect_interval_ms}ms")
+      {:noreply, schedule_reconnect(%{state | socket: nil})}
+    else
+      Logger.warning("TCP error: #{inspect(reason)}, stopping (auto_reconnect: false)")
+      {:stop, {:tcp_error, reason}, %{state | socket: nil}}
+    end
   end
 
   @impl true

--- a/lib/ib_ex/dev_server.ex
+++ b/lib/ib_ex/dev_server.ex
@@ -1,48 +1,48 @@
 defmodule IbEx.DevServer do
-    @moduledoc false
+  @moduledoc false
 
-    use Supervisor
+  use Supervisor
 
-    require Logger
+  require Logger
 
-    def start_link(opts \\ []) do
-      Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    port = Keyword.get(opts, :port, 4040)
+
+    client_opts =
+      [name: IbEx.Client, trace_messages: true]
+      |> maybe_put_env(:host, "TWS_HOST", &parse_host/1)
+      |> maybe_put_env(:port, "TWS_PORT", &String.to_integer/1)
+
+    Logger.info("DevServer starting Client with opts: #{inspect(client_opts)}")
+
+    children = [
+      {Phoenix.PubSub, name: IbEx.PubSub},
+      IbEx.TraceServer,
+      {IbEx.Client, client_opts},
+      {IbEx.Client.ContractResolver, client: IbEx.Client, name: IbEx.ContractResolver},
+      {IbEx.MarketDataManager,
+       client: IbEx.Client, resolver: IbEx.ContractResolver, pubsub: IbEx.PubSub, name: IbEx.MarketDataManager},
+      {Bandit, plug: Tidewave, port: port}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp maybe_put_env(opts, key, env_var, parser) do
+    case System.get_env(env_var) do
+      nil -> opts
+      value -> Keyword.put(opts, key, parser.(value))
     end
+  end
 
-    def init(opts) do
-      port = Keyword.get(opts, :port, 4040)
-
-      client_opts =
-        [name: IbEx.Client, trace_messages: true]
-        |> maybe_put_env(:host, "TWS_HOST", &parse_host/1)
-        |> maybe_put_env(:port, "TWS_PORT", &String.to_integer/1)
-
-      Logger.info("DevServer starting Client with opts: #{inspect(client_opts)}")
-
-      children = [
-        {Phoenix.PubSub, name: IbEx.PubSub},
-        IbEx.TraceServer,
-        {IbEx.Client, client_opts},
-        {IbEx.Client.ContractResolver, client: IbEx.Client, name: IbEx.ContractResolver},
-        {IbEx.MarketDataManager,
-         client: IbEx.Client, resolver: IbEx.ContractResolver, pubsub: IbEx.PubSub, name: IbEx.MarketDataManager},
-        {Bandit, plug: Tidewave, port: port}
-      ]
-
-      Supervisor.init(children, strategy: :one_for_one)
-    end
-
-    defp maybe_put_env(opts, key, env_var, parser) do
-      case System.get_env(env_var) do
-        nil -> opts
-        value -> Keyword.put(opts, key, parser.(value))
-      end
-    end
-
-    defp parse_host(host_string) do
-      host_string
-      |> String.split(".")
-      |> Enum.map(&String.to_integer/1)
-      |> List.to_tuple()
-    end
+  defp parse_host(host_string) do
+    host_string
+    |> String.split(".")
+    |> Enum.map(&String.to_integer/1)
+    |> List.to_tuple()
+  end
 end

--- a/lib/ib_ex/trace_server.ex
+++ b/lib/ib_ex/trace_server.ex
@@ -1,118 +1,118 @@
 defmodule IbEx.TraceServer do
-    @moduledoc """
-    Dev/test-only GenServer that captures parsed TWS messages for inspection.
+  @moduledoc """
+  Dev/test-only GenServer that captures parsed TWS messages for inspection.
 
-    Maintains a bounded FIFO buffer (default max 1000 entries) of trace entries
-    with timestamp, message struct, type module, req_id, and order_id.
+  Maintains a bounded FIFO buffer (default max 1000 entries) of trace entries
+  with timestamp, message struct, type module, req_id, and order_id.
 
-    ## Usage
+  ## Usage
 
-        IbEx.TraceServer.messages()
-        IbEx.TraceServer.messages(type: IbEx.Client.Proto.Protobuf.TickPrice)
-        IbEx.TraceServer.messages(req_id: 1)
-        IbEx.TraceServer.messages(req_id: 1, type: IbEx.Client.Proto.Protobuf.TickPrice)
-        IbEx.TraceServer.count()
-        IbEx.TraceServer.clear()
-    """
+      IbEx.TraceServer.messages()
+      IbEx.TraceServer.messages(type: IbEx.Client.Proto.Protobuf.TickPrice)
+      IbEx.TraceServer.messages(req_id: 1)
+      IbEx.TraceServer.messages(req_id: 1, type: IbEx.Client.Proto.Protobuf.TickPrice)
+      IbEx.TraceServer.count()
+      IbEx.TraceServer.clear()
+  """
 
-    use GenServer
+  use GenServer
 
-    @default_max_size 1000
+  @default_max_size 1000
 
-    defstruct buffer: :queue.new(), size: 0, max_size: @default_max_size
+  defstruct buffer: :queue.new(), size: 0, max_size: @default_max_size
 
-    # Public API
+  # Public API
 
-    def start_link(opts \\ []) do
-      max_size = Keyword.get(opts, :max_size, @default_max_size)
-      GenServer.start_link(__MODULE__, max_size, name: Keyword.get(opts, :name, __MODULE__))
-    end
+  def start_link(opts \\ []) do
+    max_size = Keyword.get(opts, :max_size, @default_max_size)
+    GenServer.start_link(__MODULE__, max_size, name: Keyword.get(opts, :name, __MODULE__))
+  end
 
-    def trace(msg, server \\ __MODULE__) do
-      GenServer.cast(server, {:trace, msg})
-    end
+  def trace(msg, server \\ __MODULE__) do
+    GenServer.cast(server, {:trace, msg})
+  end
 
-    def messages(filters \\ [], server \\ __MODULE__) do
-      GenServer.call(server, {:messages, filters})
-    end
+  def messages(filters \\ [], server \\ __MODULE__) do
+    GenServer.call(server, {:messages, filters})
+  end
 
-    def count(server \\ __MODULE__) do
-      GenServer.call(server, :count)
-    end
+  def count(server \\ __MODULE__) do
+    GenServer.call(server, :count)
+  end
 
-    def clear(server \\ __MODULE__) do
-      GenServer.call(server, :clear)
-    end
+  def clear(server \\ __MODULE__) do
+    GenServer.call(server, :clear)
+  end
 
-    # Server callbacks
+  # Server callbacks
 
-    @impl true
-    def init(max_size) do
-      {:ok, %__MODULE__{max_size: max_size}}
-    end
+  @impl true
+  def init(max_size) do
+    {:ok, %__MODULE__{max_size: max_size}}
+  end
 
-    @impl true
-    def handle_cast({:trace, msg}, state) do
-      entry = build_entry(msg)
-      {buffer, size} = enqueue(state.buffer, state.size, state.max_size, entry)
-      {:noreply, %{state | buffer: buffer, size: size}}
-    end
+  @impl true
+  def handle_cast({:trace, msg}, state) do
+    entry = build_entry(msg)
+    {buffer, size} = enqueue(state.buffer, state.size, state.max_size, entry)
+    {:noreply, %{state | buffer: buffer, size: size}}
+  end
 
-    @impl true
-    def handle_call({:messages, filters}, _from, state) do
-      entries = :queue.to_list(state.buffer)
-      result = apply_filters(entries, filters)
-      {:reply, result, state}
-    end
+  @impl true
+  def handle_call({:messages, filters}, _from, state) do
+    entries = :queue.to_list(state.buffer)
+    result = apply_filters(entries, filters)
+    {:reply, result, state}
+  end
 
-    def handle_call(:count, _from, state) do
-      {:reply, state.size, state}
-    end
+  def handle_call(:count, _from, state) do
+    {:reply, state.size, state}
+  end
 
-    def handle_call(:clear, _from, state) do
-      {:reply, :ok, %{state | buffer: :queue.new(), size: 0}}
-    end
+  def handle_call(:clear, _from, state) do
+    {:reply, :ok, %{state | buffer: :queue.new(), size: 0}}
+  end
 
-    # Private functions
+  # Private functions
 
-    defp build_entry(%module{} = msg) do
-      %{
-        timestamp: DateTime.utc_now(),
-        message: msg,
-        type: module,
-        req_id: Map.get(msg, :req_id),
-        order_id: Map.get(msg, :order_id)
-      }
-    end
+  defp build_entry(%module{} = msg) do
+    %{
+      timestamp: DateTime.utc_now(),
+      message: msg,
+      type: module,
+      req_id: Map.get(msg, :req_id),
+      order_id: Map.get(msg, :order_id)
+    }
+  end
 
-    defp build_entry(msg) do
-      %{
-        timestamp: DateTime.utc_now(),
-        message: msg,
-        type: nil,
-        req_id: nil,
-        order_id: nil
-      }
-    end
+  defp build_entry(msg) do
+    %{
+      timestamp: DateTime.utc_now(),
+      message: msg,
+      type: nil,
+      req_id: nil,
+      order_id: nil
+    }
+  end
 
-    defp enqueue(buffer, size, max_size, entry) when size >= max_size do
-      {_, buffer} = :queue.out(buffer)
-      {:queue.in(entry, buffer), size}
-    end
+  defp enqueue(buffer, size, max_size, entry) when size >= max_size do
+    {_, buffer} = :queue.out(buffer)
+    {:queue.in(entry, buffer), size}
+  end
 
-    defp enqueue(buffer, size, _max_size, entry) do
-      {:queue.in(entry, buffer), size + 1}
-    end
+  defp enqueue(buffer, size, _max_size, entry) do
+    {:queue.in(entry, buffer), size + 1}
+  end
 
-    defp apply_filters(entries, []), do: entries
+  defp apply_filters(entries, []), do: entries
 
-    defp apply_filters(entries, filters) do
-      Enum.filter(entries, fn entry ->
-        Enum.all?(filters, fn
-          {:type, type} -> entry.type == type
-          {:req_id, id} -> entry.req_id == id
-          {:order_id, id} -> entry.order_id == id
-        end)
+  defp apply_filters(entries, filters) do
+    Enum.filter(entries, fn entry ->
+      Enum.all?(filters, fn
+        {:type, type} -> entry.type == type
+        {:req_id, id} -> entry.req_id == id
+        {:order_id, id} -> entry.order_id == id
       end)
-    end
+    end)
+  end
 end

--- a/test/ib_ex/client/connection_test.exs
+++ b/test/ib_ex/client/connection_test.exs
@@ -90,4 +90,88 @@ defmodule IbEx.Client.ConnectionTest do
       :gen_tcp.close(listen_socket)
     end
   end
+
+  describe "auto_reconnect: false" do
+    @tag capture_log: true
+    test "tcp_closed stops the process instead of scheduling reconnect" do
+      state = build_state(%{auto_reconnect: false})
+
+      assert {:stop, :tcp_closed, new_state} = Connection.handle_info({:tcp_closed, :fake_socket}, state)
+
+      assert new_state.socket == nil
+      assert new_state.reconnect_timer_ref == nil
+
+      # Still notifies the client
+      assert_receive {:"$gen_cast", :connection_closed}
+    end
+
+    @tag capture_log: true
+    test "tcp_error stops the process with the error reason instead of scheduling reconnect" do
+      state = build_state(%{auto_reconnect: false})
+
+      assert {:stop, {:tcp_error, :econnreset}, new_state} =
+               Connection.handle_info({:tcp_error, :fake_socket, :econnreset}, state)
+
+      assert new_state.socket == nil
+      assert new_state.reconnect_timer_ref == nil
+
+      # Still notifies the client
+      assert_receive {:"$gen_cast", :connection_closed}
+    end
+
+    @tag capture_log: true
+    test "send_message error stops the process instead of scheduling reconnect" do
+      # We need a real (but broken) socket to trigger a send error.
+      # Create a socket and immediately close it so send fails.
+      {:ok, listen_socket} = :gen_tcp.listen(0, reuseaddr: true)
+      {:ok, port} = :inet.port(listen_socket)
+      {:ok, client_socket} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
+      :gen_tcp.close(client_socket)
+      :gen_tcp.close(listen_socket)
+
+      state = build_state(%{socket: client_socket, auto_reconnect: false})
+
+      assert {:stop, {:send_error, reason}, {:error, reason}, new_state} =
+               Connection.handle_call({:send_message, "data"}, {self(), make_ref()}, state)
+
+      assert is_atom(reason)
+
+      assert new_state.socket == nil
+    end
+  end
+
+  describe "auto_reconnect: true (default)" do
+    test "build_state defaults to auto_reconnect: true" do
+      state = build_state()
+      assert state.auto_reconnect == true
+    end
+
+    @tag capture_log: true
+    test "tcp_closed schedules reconnect when auto_reconnect is true" do
+      state = build_state(%{auto_reconnect: true})
+
+      assert {:noreply, new_state} = Connection.handle_info({:tcp_closed, :fake_socket}, state)
+
+      assert new_state.socket == nil
+      assert is_reference(new_state.reconnect_timer_ref)
+
+      assert_receive {:"$gen_cast", :connection_closed}
+
+      Process.cancel_timer(new_state.reconnect_timer_ref)
+    end
+
+    @tag capture_log: true
+    test "tcp_error schedules reconnect when auto_reconnect is true" do
+      state = build_state(%{auto_reconnect: true})
+
+      assert {:noreply, new_state} = Connection.handle_info({:tcp_error, :fake_socket, :econnreset}, state)
+
+      assert new_state.socket == nil
+      assert is_reference(new_state.reconnect_timer_ref)
+
+      assert_receive {:"$gen_cast", :connection_closed}
+
+      Process.cancel_timer(new_state.reconnect_timer_ref)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `:auto_reconnect` option to `Client.start_link/1` (default: `true`)
- When `false`, the `Connection` GenServer returns `{:stop, reason, state}` on `tcp_closed`/`tcp_error`/send errors instead of scheduling reconnection
- Enables supervisor-driven restart strategies (e.g., exponential backoff, `:rest_for_one`) by letting the process crash on connection loss

## Test plan
- [ ] Verify `auto_reconnect: false` stops Connection on `tcp_closed`
- [ ] Verify `auto_reconnect: false` stops Connection on `tcp_error`
- [ ] Verify `auto_reconnect: false` stops Connection on send error
- [ ] Verify `auto_reconnect: true` (default) preserves existing reconnect behavior
- [ ] Verify client is always notified via `connection_closed` regardless of setting
- [ ] All 784 tests pass with zero warnings